### PR TITLE
fix(abac): coerce default_effect to str at Rust boundary (0.20.10)

### DIFF
--- a/navigator_auth/abac/policies/evaluator.py
+++ b/navigator_auth/abac/policies/evaluator.py
@@ -36,6 +36,27 @@ from navigator_auth.abac.policies.resource_policy import ResourcePolicy
 logger = logging.getLogger(__name__)
 
 
+def _coerce_default_effect(value: Any) -> str:
+    """Normalize a default_effect value to 'allow' or 'deny'.
+
+    Accepts either a string ('allow'/'deny', case-insensitive) or a
+    PolicyEffect enum. Kept permissive for backward compatibility with
+    callers written against pre-0.20.9 APIs that stored enums.
+    """
+    if value is None:
+        return "deny"
+    name = getattr(value, "name", None)
+    if isinstance(name, str):
+        normalized = name.strip().lower()
+        if normalized in ("allow", "deny"):
+            return normalized
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in ("allow", "deny"):
+            return normalized
+    return "deny"
+
+
 @dataclass
 class EvaluationResult:
     """Result of policy evaluation with metadata."""
@@ -203,7 +224,7 @@ class PolicyEvaluator:
                 "Install it with: maturin develop --release (from the rs_pep directory)"
             )
         self._index = PolicyIndex()
-        self._default_effect = ABAC_DEFAULT_EFFECT
+        self._default_effect = _coerce_default_effect(ABAC_DEFAULT_EFFECT)
         self._cache_size = cache_size
         self._cache_ttl = cache_ttl_seconds
         self._cache: Dict[str, Tuple[EvaluationResult, float]] = {}
@@ -409,7 +430,7 @@ class PolicyEvaluator:
                 user_ctx,
                 env_dict,
                 owner_reports_to=owner_reports_to,
-                default_effect=self._default_effect,
+                default_effect=_coerce_default_effect(self._default_effect),
             )
 
             result = EvaluationResult(
@@ -471,7 +492,7 @@ class PolicyEvaluator:
                 rust_resources,
                 user_ctx,
                 env_dict,
-                default_effect=self._default_effect,
+                default_effect=_coerce_default_effect(self._default_effect),
             )
 
             # Strip type prefix from results

--- a/navigator_auth/version.py
+++ b/navigator_auth/version.py
@@ -6,7 +6,7 @@ __title__ = "navigator_auth"
 __description__ = (
     "Navigator Auth is an Authentication/Authorization Toolkit for aiohttp."
 )
-__version__ = "0.20.9"  # pragma: no cover
+__version__ = "0.20.10"  # pragma: no cover
 __author__ = "Jesus Lara"
 __author_email__ = "jesuslarag@gmail.com"
 __copyright__ = "Copyright (c) 2019-2025 Jesus Lara"

--- a/tests/test_default_effect_coercion.py
+++ b/tests/test_default_effect_coercion.py
@@ -1,0 +1,180 @@
+"""Tests for default_effect coercion in PolicyEvaluator.
+
+Regression coverage for 0.20.10: the Rust PEP (`rs_pep`) expects
+``default_effect`` as a Python ``str``. Older callers (code written
+against navigator-auth <= 0.20.8) stored a ``PolicyEffect`` enum on
+``PolicyEvaluator._default_effect``. The evaluator must accept both and
+always cross the Rust boundary with a string.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+
+from navigator_auth.abac.context import EvalContext
+from navigator_auth.abac.policies import Environment, PolicyEffect
+from navigator_auth.abac.policies import evaluator as evaluator_mod
+from navigator_auth.abac.policies.evaluator import (
+    _RS_PEP_AVAILABLE,
+    _coerce_default_effect,
+)
+from navigator_auth.abac.policies.resource_policy import ResourcePolicy
+from navigator_auth.abac.policies.resources import ResourceType
+
+
+class TestCoerceDefaultEffectHelper:
+    """Pure-Python unit tests — no Rust needed."""
+
+    def test_none_defaults_to_deny(self):
+        assert _coerce_default_effect(None) == "deny"
+
+    def test_string_allow_lowercase(self):
+        assert _coerce_default_effect("allow") == "allow"
+
+    def test_string_deny_lowercase(self):
+        assert _coerce_default_effect("deny") == "deny"
+
+    def test_string_mixed_case(self):
+        assert _coerce_default_effect("ALLOW") == "allow"
+        assert _coerce_default_effect("Deny") == "deny"
+
+    def test_string_with_whitespace(self):
+        assert _coerce_default_effect("  allow  ") == "allow"
+
+    def test_enum_allow(self):
+        assert _coerce_default_effect(PolicyEffect.ALLOW) == "allow"
+
+    def test_enum_deny(self):
+        assert _coerce_default_effect(PolicyEffect.DENY) == "deny"
+
+    def test_unknown_string_falls_back_to_deny(self):
+        assert _coerce_default_effect("banana") == "deny"
+
+    def test_unknown_type_falls_back_to_deny(self):
+        assert _coerce_default_effect(42) == "deny"
+
+
+@pytest.fixture
+def user_info():
+    return {
+        "username": "jlara@trocglobal.com",
+        "groups": ["engineering"],
+        "roles": ["user"],
+    }
+
+
+@pytest.fixture
+def eval_context(user_info):
+    request = MagicMock(spec=web.Request)
+    request.path = "/api/v1/user/session"
+    request.method = "GET"
+
+    class User:
+        def __init__(self):
+            self.username = user_info["username"]
+            self.groups = user_info["groups"]
+            self.id = 35
+
+    return EvalContext(request, User(), user_info, None)
+
+
+@pytest.fixture
+def environment():
+    return Environment()
+
+
+@pytest.mark.skipif(
+    not _RS_PEP_AVAILABLE,
+    reason="rs_pep Rust extension not available in this environment",
+)
+class TestEvaluatorRustBoundary:
+    """Verify the Python->Rust call always receives a string for default_effect."""
+
+    def _make_evaluator(self):
+        from navigator_auth.abac.policies.evaluator import PolicyEvaluator
+        return PolicyEvaluator()
+
+    def test_enum_assignment_is_coerced_at_call_site(
+        self, eval_context, environment
+    ):
+        evaluator = self._make_evaluator()
+        # Simulate a legacy caller assigning the enum directly.
+        evaluator._default_effect = PolicyEffect.DENY
+
+        captured = {}
+
+        def fake_evaluate_single(*args, **kwargs):
+            captured["default_effect"] = kwargs.get("default_effect")
+            return {
+                "allowed": False,
+                "effect": "deny",
+                "matched_policy": None,
+                "reason": "stub",
+            }
+
+        with patch.object(evaluator_mod, "evaluate_single", side_effect=fake_evaluate_single):
+            evaluator.check_access(
+                eval_context,
+                ResourceType.URI,
+                "/api/v1/user/session",
+                "uri:read",
+                environment,
+            )
+
+        assert isinstance(captured["default_effect"], str)
+        assert captured["default_effect"] == "deny"
+
+    def test_string_assignment_is_passed_through(
+        self, eval_context, environment
+    ):
+        evaluator = self._make_evaluator()
+        evaluator._default_effect = "allow"
+
+        captured = {}
+
+        def fake_evaluate_single(*args, **kwargs):
+            captured["default_effect"] = kwargs.get("default_effect")
+            return {
+                "allowed": True,
+                "effect": "allow",
+                "matched_policy": None,
+                "reason": "stub",
+            }
+
+        with patch.object(evaluator_mod, "evaluate_single", side_effect=fake_evaluate_single):
+            evaluator.check_access(
+                eval_context,
+                ResourceType.URI,
+                "/api/v1/user/session",
+                "uri:read",
+                environment,
+            )
+
+        assert captured["default_effect"] == "allow"
+
+    def test_filter_resources_also_coerces(self, eval_context, environment):
+        evaluator = self._make_evaluator()
+        evaluator._default_effect = PolicyEffect.DENY
+
+        captured = {}
+
+        def fake_filter(*args, **kwargs):
+            captured["default_effect"] = kwargs.get("default_effect")
+            return {"allowed": [], "denied": args[1] if len(args) > 1 else []}
+
+        with patch.object(evaluator_mod, "filter_resources_batch", side_effect=fake_filter):
+            evaluator.filter_resources(
+                eval_context,
+                ResourceType.URI,
+                ["/api/v1/a", "/api/v1/b"],
+                "uri:read",
+                environment,
+            )
+
+        assert isinstance(captured["default_effect"], str)
+        assert captured["default_effect"] == "deny"
+
+    def test_init_default_is_string(self):
+        evaluator = self._make_evaluator()
+        assert isinstance(evaluator._default_effect, str)
+        assert evaluator._default_effect in ("allow", "deny")


### PR DESCRIPTION
## Summary

- Accept both ``str`` and ``PolicyEffect`` enum for the ABAC default effect and always convert to a lowercase string before calling the Rust ``rs_pep`` engine.
- Fixes the 0.20.9 regression where legacy callers (navigator-auth <= 0.20.8 and downstream consumers like **ai-parrot**) still hold ``PolicyEffect.DENY`` on ``PolicyEvaluator._default_effect``. The Rust ``evaluate_single`` / ``filter_resources_batch`` functions now require a Python ``str``, which surfaces as:

  > argument 'default_effect': 'PolicyEffect' object cannot be converted to 'PyString'

  and collapses every request into a fail-closed deny.
- Bumps version to **0.20.10**.

## Changes

- ``navigator_auth/abac/policies/evaluator.py``
  - New helper ``_coerce_default_effect(value) -> str`` — accepts ``str`` (any case), ``PolicyEffect`` enum, or ``None``; returns ``"allow"`` / ``"deny"``; fallback ``"deny"`` for unknown inputs (fail-closed).
  - ``PolicyEvaluator.__init__`` coerces ``ABAC_DEFAULT_EFFECT`` on assignment.
  - Both Rust call sites (``evaluate_single``, ``filter_resources_batch``) re-apply the coercion so code that mutates ``evaluator._default_effect = PolicyEffect.DENY`` after init still works.
- ``tests/test_default_effect_coercion.py`` — 13 new tests (9 helper cases + 4 Rust-boundary mocks covering enum, string, init, and ``filter_resources``).
- ``navigator_auth/version.py`` — ``0.20.9`` → ``0.20.10``.

## Test plan

- [x] ``pytest tests/test_default_effect_coercion.py -v`` → 13 passed
- [x] Verified existing ``tests/test_unified_evaluation.py`` + ``tests/test_policy_evaluation.py`` still pass (no regressions)
- [ ] Validate in **ai-parrot** that upgrading to 0.20.10 resolves the ``/api/v1/user/session`` and ``/api/v1/programs_user`` DENY cascade
- [ ] Confirm published wheel contains ``navigator_auth/rs_pep.cpython-*.so`` for all supported CPython versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)