### PR TITLE
fix(deps): bump pyo3 0.22 -> 0.24 (RUSTSEC-2025-0020)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["navigator_auth/rs_pep"]
 resolver = "2"
 
 [workspace.dependencies]
-pyo3 = { version = "0.22", features = ["extension-module"] }
+pyo3 = { version = "0.24", features = ["extension-module"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rayon = "1.10"

--- a/navigator_auth/rs_pep/src/lib.rs
+++ b/navigator_auth/rs_pep/src/lib.rs
@@ -519,7 +519,7 @@ fn filter_resources_batch(
     });
 
     // Build result dict
-    let result_dict = PyDict::new_bound(py);
+    let result_dict = PyDict::new(py);
     let mut allowed_list: Vec<String> = Vec::new();
     let mut denied_list: Vec<String> = Vec::new();
 
@@ -534,7 +534,7 @@ fn filter_resources_batch(
     result_dict.set_item("allowed", allowed_list)?;
     result_dict.set_item("denied", denied_list)?;
 
-    Ok(result_dict.into())
+    Ok(result_dict.into_any().unbind())
 }
 
 /// Evaluate a single resource against policies.
@@ -627,13 +627,13 @@ fn evaluate_single(
     });
 
     // Build result dict
-    let result_dict = PyDict::new_bound(py);
+    let result_dict = PyDict::new(py);
     result_dict.set_item("allowed", result.allowed)?;
     result_dict.set_item("effect", result.effect)?;
     result_dict.set_item("matched_policy", result.matched_policy)?;
     result_dict.set_item("reason", result.reason)?;
 
-    Ok(result_dict.into())
+    Ok(result_dict.into_any().unbind())
 }
 
 /// Navigator Auth PEP module — high-performance batch resource filtering.

--- a/navigator_auth/version.py
+++ b/navigator_auth/version.py
@@ -6,7 +6,7 @@ __title__ = "navigator_auth"
 __description__ = (
     "Navigator Auth is an Authentication/Authorization Toolkit for aiohttp."
 )
-__version__ = "0.21.0"  # pragma: no cover
+__version__ = "0.21.1"  # pragma: no cover
 __author__ = "Jesus Lara"
 __author_email__ = "jesuslarag@gmail.com"
 __copyright__ = "Copyright (c) 2019-2025 Jesus Lara"


### PR DESCRIPTION
## Summary

Bumps **pyo3 0.22 → 0.24.2** to close the 6 Dependabot alerts on the pyo3 crate family — all instances of the same advisory **RUSTSEC-2025-0020 / GHSA-pph8-gcv7-4qj5** (`PyString` buffer overflow), fixed upstream in 0.24.

Affected crates resolved: `pyo3`, `pyo3-ffi`, `pyo3-macros`, `pyo3-macros-backend`, `pyo3-build-config`.

## Changes

- `Cargo.toml`: `pyo3 = "0.22"` → `"0.24"`
- `Cargo.lock`: regenerated (pyo3 0.24.2 + family)
- `navigator_auth/rs_pep/src/lib.rs`: migrate two APIs removed since 0.23:
  - `PyDict::new_bound(py)` → `PyDict::new(py)`
  - `Bound` → `PyObject` return via `.into_any().unbind()`
- `version.py`: `0.21.0` → `0.21.1` (security patch release)

## Verification

- ✅ `cargo test` — 10/10 Rust unit tests pass
- ✅ `cargo build --release` — clean, no warnings
- ✅ Python smoke test against the 0.24.2 build: `filter_resources_batch`, `evaluate_single`, and tenant isolation all correct

## Notes

The wheel is built with **setuptools-rust** (not maturin); CI / `pip install -e .` recompiles `rs_pep` with the new pyo3 automatically. Recommend running the full pytest suite in CI before merge.

The 7th Dependabot alert is from a different dependency and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)