### PR TITLE
feat(authz): temporary User-Agent geo-fence (USERAGENT_SECURITY) for PowerBI clients

### DIFF
--- a/navigator_auth/authorizations/_client_ip.py
+++ b/navigator_auth/authorizations/_client_ip.py
@@ -1,0 +1,46 @@
+"""Shared helpers to resolve the real client IP behind trusted proxies.
+
+Used by both ``authz_allowed_ips`` (CIDR matching) and ``authz_useragent``
+(geo-fencing) so the trusted-proxy / ``X-Forwarded-For`` logic lives in one
+place.
+"""
+import ipaddress
+import logging
+from aiohttp import web
+
+IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+
+def parse_proxies(entries: list[str]) -> set[IPAddress]:
+    """Build a set of proxy IP addresses, skipping (and logging) invalid ones."""
+    proxies: set[IPAddress] = set()
+    for entry in entries:
+        try:
+            proxies.add(ipaddress.ip_address(entry))
+        except ValueError:
+            logging.warning(f"authz: ignoring invalid trusted proxy IP: {entry}")
+    return proxies
+
+
+def get_client_ip(
+    request: web.Request,
+    proxies: set[IPAddress] | None = None,
+) -> str | None:
+    """Extract the real client IP, respecting trusted proxies.
+
+    When the direct TCP peer is one of ``proxies``, the left-most entry of
+    ``X-Forwarded-For`` (the original client) is returned; otherwise the
+    direct peer (``request.remote``) is used.
+    """
+    remote = request.remote
+    if not remote:
+        return None
+    try:
+        remote_addr = ipaddress.ip_address(remote)
+    except ValueError:
+        return None
+    if proxies and remote_addr in proxies:
+        forwarded = request.headers.get("X-Forwarded-For", "")
+        if forwarded:
+            return forwarded.split(",")[0].strip()
+    return remote

--- a/navigator_auth/authorizations/_geoip.py
+++ b/navigator_auth/authorizations/_geoip.py
@@ -1,0 +1,63 @@
+"""Country geolocation via the MaxMind GeoLite2 database (optional).
+
+The ``geoip2`` package and a GeoLite2-Country ``.mmdb`` file are only required
+when ``USERAGENT_SECURITY`` is enabled. The reader is opened lazily, once, and
+cached for the lifetime of the process. Any failure (missing package, missing
+database, lookup error) resolves to ``None`` so callers can *fail closed*.
+"""
+import logging
+from ..conf import GEOIP_DATABASE
+
+_reader = None
+_loaded = False
+
+
+def _load_reader():
+    """Open the GeoLite2 reader once; return None if unavailable."""
+    global _reader, _loaded
+    _loaded = True
+    try:
+        import geoip2.database
+    except ImportError:
+        logging.warning(
+            "authz: USERAGENT_SECURITY requires the 'geoip2' package "
+            "(pip install navigator-auth[geoip]); geo-fencing will deny."
+        )
+        return None
+    try:
+        _reader = geoip2.database.Reader(GEOIP_DATABASE)
+        logging.info(f"authz: GeoIP database loaded from {GEOIP_DATABASE}")
+    except (FileNotFoundError, OSError, ValueError) as exc:
+        logging.warning(
+            f"authz: cannot open GeoIP database '{GEOIP_DATABASE}': {exc}; "
+            "geo-fencing will deny."
+        )
+        _reader = None
+    return _reader
+
+
+def lookup_country(ip: str | None) -> str | None:
+    """Return the ISO-3166 country code for ``ip`` (e.g. ``'US'``) or None."""
+    if not ip:
+        return None
+    if not _loaded:
+        _load_reader()
+    if _reader is None:
+        return None
+    try:
+        return _reader.country(ip).country.iso_code
+    except Exception as exc:  # noqa: BLE001 - AddressNotFound, ValueError, etc.
+        logging.debug(f"authz: GeoIP lookup miss for {ip}: {exc}")
+        return None
+
+
+def reset_reader() -> None:
+    """Drop the cached reader (used by tests)."""
+    global _reader, _loaded
+    if _reader is not None:
+        try:
+            _reader.close()
+        except Exception:  # noqa: BLE001
+            pass
+    _reader = None
+    _loaded = False

--- a/navigator_auth/authorizations/allowed_ips.py
+++ b/navigator_auth/authorizations/allowed_ips.py
@@ -3,6 +3,7 @@ import ipaddress
 import logging
 from aiohttp import web
 from ..conf import ALLOWED_IPS, ALLOWED_IP_TRUSTED_PROXIES
+from ._client_ip import get_client_ip, parse_proxies
 from .abstract import BaseAuthzHandler
 
 
@@ -19,16 +20,9 @@ class authz_allowed_ips(BaseAuthzHandler):
 
     def __init__(self):
         self._networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
-        self._proxies: set[ipaddress.IPv4Address | ipaddress.IPv6Address] = set()
         for entry in ALLOWED_IPS:
             self._add_network(entry)
-        for entry in ALLOWED_IP_TRUSTED_PROXIES:
-            try:
-                self._proxies.add(ipaddress.ip_address(entry))
-            except ValueError:
-                logging.warning(
-                    f"authz_allowed_ips: ignoring invalid proxy IP: {entry}"
-                )
+        self._proxies = parse_proxies(ALLOWED_IP_TRUSTED_PROXIES)
 
     def _add_network(self, entry: str) -> bool:
         try:
@@ -56,18 +50,7 @@ class authz_allowed_ips(BaseAuthzHandler):
 
     def _get_client_ip(self, request: web.Request) -> str | None:
         """Extract the real client IP, respecting trusted proxies."""
-        remote = request.remote
-        if not remote:
-            return None
-        try:
-            remote_addr = ipaddress.ip_address(remote)
-        except ValueError:
-            return None
-        if self._proxies and remote_addr in self._proxies:
-            forwarded = request.headers.get("X-Forwarded-For", "")
-            if forwarded:
-                return forwarded.split(",")[0].strip()
-        return remote
+        return get_client_ip(request, self._proxies)
 
     async def check_authorization(self, request: web.Request) -> bool:
         if not self._networks:

--- a/navigator_auth/authorizations/useragent.py
+++ b/navigator_auth/authorizations/useragent.py
@@ -1,20 +1,53 @@
 import logging
 from aiohttp import web
-from ..conf import ALLOWED_UA
+from ..conf import (
+    ALLOWED_UA,
+    ALLOWED_IP_TRUSTED_PROXIES,
+    USERAGENT_SECURITY,
+    USERAGENT_ALLOWED_COUNTRIES,
+)
+from ._client_ip import get_client_ip, parse_proxies
+from ._geoip import lookup_country
 from .abstract import BaseAuthzHandler
 
 
 class authz_useragent(BaseAuthzHandler):
+    """User-Agent based authorization.
+
+    Allows any request whose ``User-Agent`` matches one of ``ALLOWED_UA``
+    (case-insensitive substring match).
+
+    When ``USERAGENT_SECURITY`` is enabled a matching User-Agent is necessary
+    but **not sufficient**: the real client IP must also geolocate to one of
+    ``USERAGENT_ALLOWED_COUNTRIES`` (default ``US, CA``). This is a temporary
+    hardening for service clients (e.g. PowerBI / Power Query) that cannot be
+    pinned to a CIDR range while they migrate to API-key authentication.
+
+    Lookups fail **closed**: if the country cannot be determined (no GeoIP
+    database, package missing, or unknown IP) the request is denied.
     """
-    User Agent.
-        Allow Any request Coming from a Service
-        Identified by its User-Agent string.
-    """
+
+    def __init__(self):
+        self._proxies = parse_proxies(ALLOWED_IP_TRUSTED_PROXIES)
 
     async def check_authorization(self, request: web.Request) -> bool:
         ua = request.headers.get("User-Agent", "").lower()
-        for key in ALLOWED_UA:
-            if key.lower() in ua:
-                logging.debug("Authorization: allowing Service based on User-Agent")
-                return True
+        if not any(key.lower() in ua for key in ALLOWED_UA):
+            return False
+        if not USERAGENT_SECURITY:
+            logging.debug("Authorization: allowing Service based on User-Agent")
+            return True
+        # Geo-fence: User-Agent match must come from an allowed country.
+        client_ip = get_client_ip(request, self._proxies)
+        country = lookup_country(client_ip)
+        if country in USERAGENT_ALLOWED_COUNTRIES:
+            logging.info(
+                "Authorization: allowing User-Agent service from "
+                f"{client_ip} ({country})"
+            )
+            return True
+        logging.warning(
+            "Authorization: User-Agent matched but denied by geo-fence "
+            f"ip={client_ip} country={country or 'unknown'}"
+        )
         return False

--- a/navigator_auth/conf.py
+++ b/navigator_auth/conf.py
@@ -164,6 +164,29 @@ ALLOWED_UA = [
     if e.strip() != ""
 ]
 
+### User-Agent authorization hardening (geo-fence).
+# When True, authz_useragent requires a matching User-Agent AND that the
+# real client IP geolocates to one of USERAGENT_ALLOWED_COUNTRIES. This is a
+# temporary measure for service clients (e.g. PowerBI) that cannot be pinned
+# to a CIDR range while they migrate to API-key authentication.
+USERAGENT_SECURITY = config.getboolean("USERAGENT_SECURITY", fallback=False)
+
+### ISO-3166 country codes allowed when USERAGENT_SECURITY is on:
+USERAGENT_ALLOWED_COUNTRIES = [
+    e.strip().upper()
+    for e in config.get(
+        "USERAGENT_ALLOWED_COUNTRIES", section="auth", fallback="US,CA"
+    ).split(",")
+    if e.strip()
+]
+
+### Path to the MaxMind GeoLite2-Country database (.mmdb) for geo-fencing:
+GEOIP_DATABASE = config.get(
+    "GEOIP_DATABASE",
+    section="auth",
+    fallback="/etc/navigator/GeoLite2-Country.mmdb",
+)
+
 ## Basic Authorization Middlewares
 AUTHORIZATION_MIDDLEWARES = ()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dependencies = [
 
 [project.optional-dependencies]
 uvloop = ["uvloop>=0.20.0"]
+geoip = ["geoip2>=4.7.0"]
 
 [project.urls]
 Homepage = "https://github.com/phenobarbital/navigator-auth"

--- a/tests/test_useragent_geo.py
+++ b/tests/test_useragent_geo.py
@@ -1,0 +1,152 @@
+"""Tests for User-Agent authorization and the optional geo-fence.
+
+The GeoIP database lookup is mocked, so these tests do not require the
+``geoip2`` package or a ``.mmdb`` file.
+"""
+import ipaddress
+import pytest
+from navigator_auth.authorizations import useragent as ua_mod
+from navigator_auth.authorizations.useragent import authz_useragent
+from navigator_auth.authorizations._client_ip import get_client_ip, parse_proxies
+
+POWERBI_UA = "Microsoft.Data.Mashup (https://go.microsoft.com/fwlink/?LinkID=304225)"
+
+
+class FakeRequest:
+    """Minimal stand-in for aiohttp.web.Request."""
+
+    def __init__(self, headers=None, remote="127.0.0.1"):
+        self.headers = headers or {}
+        self.remote = remote
+
+
+# --------------------------------------------------------------------------- #
+# get_client_ip / parse_proxies
+# --------------------------------------------------------------------------- #
+def test_parse_proxies_skips_invalid():
+    proxies = parse_proxies(["127.0.0.1", "not-an-ip", "10.0.0.1"])
+    assert ipaddress.ip_address("127.0.0.1") in proxies
+    assert ipaddress.ip_address("10.0.0.1") in proxies
+    assert len(proxies) == 2
+
+
+def test_get_client_ip_uses_xff_behind_trusted_proxy():
+    proxies = parse_proxies(["127.0.0.1"])
+    req = FakeRequest(
+        headers={"X-Forwarded-For": "181.95.151.21, 10.0.0.5"},
+        remote="127.0.0.1",
+    )
+    assert get_client_ip(req, proxies) == "181.95.151.21"
+
+
+def test_get_client_ip_ignores_xff_from_untrusted_peer():
+    proxies = parse_proxies(["127.0.0.1"])
+    req = FakeRequest(
+        headers={"X-Forwarded-For": "1.2.3.4"},
+        remote="8.8.8.8",  # not a trusted proxy
+    )
+    assert get_client_ip(req, proxies) == "8.8.8.8"
+
+
+def test_get_client_ip_no_remote():
+    assert get_client_ip(FakeRequest(remote=None), set()) is None
+
+
+# --------------------------------------------------------------------------- #
+# authz_useragent — security OFF (legacy behaviour)
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def patch_ua(monkeypatch):
+    """Helper to set module-level config for the useragent backend."""
+    def _apply(*, allowed_ua, security, countries=("US", "CA"), proxies=("127.0.0.1",)):
+        monkeypatch.setattr(ua_mod, "ALLOWED_UA", list(allowed_ua))
+        monkeypatch.setattr(ua_mod, "USERAGENT_SECURITY", security)
+        monkeypatch.setattr(ua_mod, "USERAGENT_ALLOWED_COUNTRIES", list(countries))
+        monkeypatch.setattr(ua_mod, "ALLOWED_IP_TRUSTED_PROXIES", list(proxies))
+    return _apply
+
+
+@pytest.mark.asyncio
+async def test_ua_no_match_denies(patch_ua):
+    patch_ua(allowed_ua=["Microsoft.Data.Mashup"], security=False)
+    handler = authz_useragent()
+    req = FakeRequest(headers={"User-Agent": "curl/8.0"})
+    assert await handler.check_authorization(req) is False
+
+
+@pytest.mark.asyncio
+async def test_ua_match_security_off_allows(patch_ua):
+    patch_ua(allowed_ua=["Microsoft.Data.Mashup"], security=False)
+    handler = authz_useragent()
+    req = FakeRequest(headers={"User-Agent": POWERBI_UA})
+    assert await handler.check_authorization(req) is True
+
+
+# --------------------------------------------------------------------------- #
+# authz_useragent — security ON (geo-fence)
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_geofence_allows_us(patch_ua, monkeypatch):
+    patch_ua(allowed_ua=["Microsoft.Data.Mashup"], security=True)
+    monkeypatch.setattr(ua_mod, "lookup_country", lambda ip: "US")
+    handler = authz_useragent()
+    req = FakeRequest(
+        headers={"User-Agent": POWERBI_UA, "X-Forwarded-For": "23.45.67.89"},
+        remote="127.0.0.1",
+    )
+    assert await handler.check_authorization(req) is True
+
+
+@pytest.mark.asyncio
+async def test_geofence_allows_canada(patch_ua, monkeypatch):
+    patch_ua(allowed_ua=["Microsoft.Data.Mashup"], security=True)
+    monkeypatch.setattr(ua_mod, "lookup_country", lambda ip: "CA")
+    handler = authz_useragent()
+    req = FakeRequest(
+        headers={"User-Agent": POWERBI_UA, "X-Forwarded-For": "99.224.1.1"},
+        remote="127.0.0.1",
+    )
+    assert await handler.check_authorization(req) is True
+
+
+@pytest.mark.asyncio
+async def test_geofence_blocks_foreign_country(patch_ua, monkeypatch):
+    # 181.95.151.21 (the ngrok log example) geolocates to Paraguay -> blocked.
+    patch_ua(allowed_ua=["Microsoft.Data.Mashup"], security=True)
+    monkeypatch.setattr(ua_mod, "lookup_country", lambda ip: "PY")
+    handler = authz_useragent()
+    req = FakeRequest(
+        headers={"User-Agent": POWERBI_UA, "X-Forwarded-For": "181.95.151.21"},
+        remote="127.0.0.1",
+    )
+    assert await handler.check_authorization(req) is False
+
+
+@pytest.mark.asyncio
+async def test_geofence_fails_closed_on_unknown(patch_ua, monkeypatch):
+    # No GeoIP DB / unknown IP -> lookup returns None -> deny.
+    patch_ua(allowed_ua=["Microsoft.Data.Mashup"], security=True)
+    monkeypatch.setattr(ua_mod, "lookup_country", lambda ip: None)
+    handler = authz_useragent()
+    req = FakeRequest(
+        headers={"User-Agent": POWERBI_UA, "X-Forwarded-For": "23.45.67.89"},
+        remote="127.0.0.1",
+    )
+    assert await handler.check_authorization(req) is False
+
+
+@pytest.mark.asyncio
+async def test_geofence_requires_ua_first(patch_ua, monkeypatch):
+    # Non-matching UA is denied before any geo lookup happens.
+    patch_ua(allowed_ua=["Microsoft.Data.Mashup"], security=True)
+    calls = []
+
+    def _spy(ip):
+        calls.append(ip)
+        return "US"
+
+    monkeypatch.setattr(ua_mod, "lookup_country", _spy)
+    handler = authz_useragent()
+    req = FakeRequest(headers={"User-Agent": "curl/8.0"}, remote="127.0.0.1")
+    assert await handler.check_authorization(req) is False
+    assert calls == []  # geo lookup never invoked


### PR DESCRIPTION
## Summary

Service clients like **PowerBI Desktop / Power Query** connect from dynamic ISP IPs and cannot be pinned to a CIDR range, so the existing `allowed_ips` (CIDR) backend can't authorize them. This adds a **temporary geo-fence** to `authz_useragent` to bridge those clients until they migrate to API-key authentication.

When `USERAGENT_SECURITY` is enabled, a matching `User-Agent` is necessary but **not sufficient**: the real client IP must also geolocate (MaxMind GeoLite2) to one of `USERAGENT_ALLOWED_COUNTRIES` (default `US,CA`).

## Behavior

- `USERAGENT_SECURITY=False` (**default**): identical to current behavior — UA match alone authorizes. No risk to existing deployments.
- `USERAGENT_SECURITY=True`: UA must match **and** the client IP must resolve to an allowed country.
- **Fails closed**: missing `geoip2` package, missing `.mmdb`, or unknown IP → deny (logged at WARNING). The geo lookup runs only *after* the UA matches.

## Changes

- **`authorizations/_client_ip.py`** (new) — shared `get_client_ip()` / `parse_proxies()`; the trusted-proxy + `X-Forwarded-For` extraction previously private to `authz_allowed_ips`.
- **`authorizations/_geoip.py`** (new) — lazy, cached MaxMind GeoLite2 reader; `lookup_country()`.
- **`authorizations/useragent.py`** — geo-fence gated by `USERAGENT_SECURITY`.
- **`authorizations/allowed_ips.py`** — refactored to reuse `_client_ip` (no behavior change).
- **`conf.py`** — `USERAGENT_SECURITY`, `USERAGENT_ALLOWED_COUNTRIES`, `GEOIP_DATABASE`.
- **`pyproject.toml`** — new optional extra `geoip = ["geoip2>=4.7.0"]`.
- **`tests/test_useragent_geo.py`** (new) — 11 tests (GeoIP mocked; no DB needed).

## Deploy

```ini
AUTHORIZATION_BACKENDS = allow_hosts,allowed_ips,useragent
ALLOWED_UA = Microsoft.Data.Mashup
ALLOWED_IP_TRUSTED_PROXIES = 127.0.0.1   # trust X-Forwarded-For from the tunnel/proxy
USERAGENT_SECURITY = true
USERAGENT_ALLOWED_COUNTRIES = US,CA
GEOIP_DATABASE = /etc/navigator/GeoLite2-Country.mmdb
```

Then `uv pip install 'navigator-auth[geoip]'` and place the GeoLite2-Country DB at that path (keep fresh via `geoipupdate`).

## Tests

```bash
pytest tests/test_useragent_geo.py -q   # 11 passed
```

> Pre-existing unrelated failure `tests/test_allowed.py::test_policy_fits` (ABAC) fails identically on `dev`; this branch does not touch ABAC.

## Notes / risks

- Geolocation is probabilistic (VPNs, mobile carriers misattribute) — intended as a **temporary** bridge, not a replacement for the API-key migration.
- `User-Agent` is spoofable; the geo-fence raises the bar (spoof UA **and** originate from US/CA) but is not authentication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
