### PR TITLE
feat(audit): tenant scoping + query() API on AuditLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Unreleased
+
+- **Audit log — tenant scoping & query API.** `AuditLog.log()` now accepts an
+  optional keyword-only `tenant`, threaded to every backend (SQL column,
+  document field, influx tag, logger message). New `AuditLog.query(*, tenant, ...)`
+  reads entries back, always constrained to one tenant (SQL backends; other
+  families degrade to `[]` with a warning). Added the pure `build_select()`
+  helper and a `tenant` column/index on the audit table. Backwards-compatible —
+  existing PDP callers are unaffected. See `documentation/audit-log.md`.
+
 # v0.0.6
 
 - NoAuth, Basic Authentication

--- a/documentation/audit-log.md
+++ b/documentation/audit-log.md
@@ -87,10 +87,47 @@ SQL and document backends store a flat record with these columns/fields:
 | `rule`        | string \| null    | Matched policy rule, if any.                 |
 | `username`    | string            | Subject username.                            |
 | `user_id`     | int \| null       | Subject id.                                  |
+| `tenant`      | string \| null    | Owning tenant (see *Tenant scoping* below).  |
 
 The InfluxDB backend stores the same information as a point in the `audit`
-measurement: `status` as a field, and host/region/message/answer/username/user
+measurement: `status` as a field, and host/region/message/answer/username/user/tenant
 as tags.
+
+## Tenant scoping & querying
+
+Audit entries carry an optional **`tenant`** so a multi-tenant deployment can
+attribute — and, crucially, read back — decisions per tenant (mirroring the
+per-tenant policy scoping in `sdd/specs/per-tenant-policy-scoping.spec.md`).
+
+### Writing with a tenant
+
+`AuditLog.log()` accepts a keyword-only `tenant`; it is threaded to every write
+family (SQL column, document field, influx tag, logger message). It is optional,
+so existing PDP callers (`log(answer, status, user)`) are unaffected.
+
+```python
+await audit.log(answer, status, user, tenant="acme")
+```
+
+### Reading back — `AuditLog.query()`
+
+```python
+rows = await audit.query(
+    tenant="acme",                 # REQUIRED — always constrains the read
+    status="DENY",                 # optional equality filters
+    user_id=42, username="alice", rule="rule-1",
+    since=start, until=end,        # optional inclusive timestamp range
+    limit=100, offset=0,           # pagination (newest first)
+)
+```
+
+- **`tenant` is mandatory** and is always the first `WHERE` predicate — a query
+  can never span tenants (passing `tenant=None` raises `ValueError`).
+- Structured `query()` is implemented for **SQL backends only**. For the
+  `influx`, `mongo`/`documentdb` and `log` families it logs a warning and returns
+  `[]` (those stores remain write-only through this API — query them directly).
+- Reads are **best-effort**: driver errors are caught, logged, and surface as `[]`,
+  consistent with the write side.
 
 ## Examples
 
@@ -118,9 +155,24 @@ CREATE TABLE audit_log (
     message     text,
     rule        text,
     username    text,
-    user_id     integer
+    user_id     integer,
+    tenant      text
 );
+
+-- Speeds up the tenant-scoped, newest-first reads issued by AuditLog.query().
+CREATE INDEX idx_audit_log_tenant_ts ON audit_log (tenant, timestamp DESC);
 ```
+
+> **Migration (existing deployments).** The `tenant` column is additive and
+> nullable, so adding it is non-breaking:
+>
+> ```sql
+> ALTER TABLE audit_log ADD COLUMN tenant text;
+> CREATE INDEX idx_audit_log_tenant_ts ON audit_log (tenant, timestamp DESC);
+> ```
+>
+> DDL/migrations are owned by the consuming service — `navigator-auth` does not
+> manage them.
 
 ### MySQL / MariaDB
 
@@ -160,9 +212,13 @@ AUDIT_PARAMSTYLE=qmark           # tell AuditLog which placeholder to emit
 
 - `resolve_paramstyle(backend, default)` — maps a driver name to its dialect.
 - `build_placeholders(paramstyle, count)` — renders the bind placeholders.
-- `build_insert(table, record, paramstyle)` — assembles the `(sql, values)`
+- `build_insert(table, record, paramstyle)` — assembles the `INSERT` `(sql, values)`
   pair.
+- `build_select(table, conditions, paramstyle, *, order_by, descending, limit,
+  offset)` — assembles the `SELECT` `(sql, values)` pair for `query()`; each
+  condition is a `(column, operator, value)` triple with the value bound as a
+  placeholder, `LIMIT`/`OFFSET` inlined as coerced ints.
 
-These three helpers are pure and unit-tested in
+These helpers are pure and unit-tested in
 `tests/test_audit_backends.py` (no live database required). Driver I/O is
 exercised in integration tests.

--- a/navigator_auth/abac/audit.py
+++ b/navigator_auth/abac/audit.py
@@ -17,8 +17,19 @@ SQL           any other asyncdb driver (``pg``,           parameterised ``INSERT
 
 SQL drivers differ only in their parameter placeholder dialect. That mapping is
 resolved by :func:`resolve_paramstyle` and the statement is assembled by the
-pure helpers :func:`build_placeholders` / :func:`build_insert`, which are unit
-tested independently of any live database.
+pure helpers :func:`build_placeholders` / :func:`build_insert` / :func:`build_select`,
+which are unit tested independently of any live database.
+
+Tenant scoping
+--------------
+Every record carries an optional ``tenant`` so a multi-tenant deployment can
+attribute — and, crucially, *read back* — audit entries per tenant.
+:meth:`AuditLog.log` accepts a keyword-only ``tenant`` and threads it to every
+write family (SQL column, document field, influx tag, logger message).
+:meth:`AuditLog.query` reads entries back and **always** constrains by tenant to
+prevent cross-tenant leakage. Structured ``query()`` is currently implemented
+for SQL backends only; other families remain write-only and ``query()`` returns
+an empty list with a warning (query the backing store directly).
 """
 from datetime import datetime, timezone
 import socket
@@ -109,8 +120,58 @@ def build_insert(table: str, record: dict, paramstyle: str) -> tuple[str, list]:
     return sql, values
 
 
-def _build_record(answer, status, user, host: str) -> dict:
-    """Build a flat audit record usable by db and influx backends."""
+def build_select(
+    table: str,
+    conditions: list,
+    paramstyle: str,
+    *,
+    order_by: str = None,
+    descending: bool = True,
+    limit: int = None,
+    offset: int = None,
+) -> tuple[str, list]:
+    """Assemble a parameterised ``SELECT`` from equality/range conditions.
+
+    Args:
+        table: Fully-qualified table name.
+        conditions: A list of ``(column, operator, value)`` triples, ANDed
+            together — e.g. ``[("tenant", "=", t), ("timestamp", ">=", since)]``.
+            The operator is a literal SQL comparison (``=``, ``>=``, ``<=``);
+            the value is always bound as a placeholder.
+        paramstyle: Placeholder dialect (see :func:`build_placeholders`).
+        order_by: Optional column to sort by.
+        descending: Sort direction when ``order_by`` is set.
+        limit: Optional ``LIMIT``. Coerced to ``int`` (defence against injection
+            since it is inlined, not bound).
+        offset: Optional ``OFFSET``. Coerced to ``int``.
+
+    Returns:
+        A ``(sql, values)`` tuple; ``values`` preserves condition order.
+    """
+    values = [value for (_col, _op, value) in conditions]
+    placeholders = build_placeholders(paramstyle, len(values))
+    where_parts = [
+        f"{col} {op} {ph}"
+        for (col, op, _value), ph in zip(conditions, placeholders)
+    ]
+    sql = f"SELECT * FROM {table}"
+    if where_parts:
+        sql += " WHERE " + " AND ".join(where_parts)
+    if order_by:
+        sql += f" ORDER BY {order_by} {'DESC' if descending else 'ASC'}"
+    if limit is not None:
+        sql += f" LIMIT {int(limit)}"
+    if offset:
+        sql += f" OFFSET {int(offset)}"
+    return sql, values
+
+
+def _build_record(answer, status, user, host: str, *, tenant: str = None) -> dict:
+    """Build a flat audit record usable by db and influx backends.
+
+    ``tenant`` is optional so existing PDP callers are unaffected; when
+    provided it is persisted as a first-class column/field for per-tenant reads.
+    """
     return {
         "timestamp": datetime.now(timezone.utc),
         "environment": ENVIRONMENT,
@@ -121,6 +182,7 @@ def _build_record(answer, status, user, host: str) -> dict:
         "rule": getattr(answer, "rule", None),
         "username": user.username if hasattr(user, "username") else str(user),
         "user_id": user.id if hasattr(user, "id") else None,
+        "tenant": tenant,
     }
 
 
@@ -212,24 +274,35 @@ class AuditLog:
     # Logging methods
     # ------------------------------------------------------------------
 
-    async def log(self, answer, status, user):
+    async def log(self, answer, status, user, *, tenant: str = None):
+        """Record an access decision.
+
+        Args:
+            answer: The PDP decision object (exposes ``response`` and ``rule``).
+            status: Decision status (e.g. ``"ALLOW"`` / ``"DENY"``).
+            user: The subject; ``username`` and ``id`` are read if present.
+            tenant: Optional tenant identifier persisted with the record so the
+                entry can later be read back per tenant via :meth:`query`.
+                Backwards-compatible: existing callers omit it.
+        """
         if self._family == "log":
-            self._log_to_logger(answer, status, user)
+            self._log_to_logger(answer, status, user, tenant=tenant)
             return
         if self._family == "timeseries":
-            await self._log_to_influx(answer, status, user)
+            await self._log_to_influx(answer, status, user, tenant=tenant)
         elif self._family == "document":
-            await self._log_to_document(answer, status, user)
+            await self._log_to_document(answer, status, user, tenant=tenant)
         else:  # sql
-            await self._log_to_db(answer, status, user)
+            await self._log_to_db(answer, status, user, tenant=tenant)
 
-    def _log_to_logger(self, answer, status, user):
+    def _log_to_logger(self, answer, status, user, *, tenant: str = None):
         username = user.username if hasattr(user, "username") else user
+        scope = f" [tenant={tenant}]" if tenant else ""
         logger.info(
-            f"Access {status} by: {answer.response} to user {username}"
+            f"Access {status} by: {answer.response} to user {username}{scope}"
         )
 
-    async def _log_to_influx(self, answer, status, user):
+    async def _log_to_influx(self, answer, status, user, *, tenant: str = None):
         from asyncdb.exceptions import DriverError
 
         async with await self._driver.connection() as conn:
@@ -247,30 +320,138 @@ class AuditLog:
                         "answer": str(answer),
                         "username": user.username if hasattr(user, "username") else str(user),
                         "user": user.id if hasattr(user, "id") else None,
+                        "tenant": tenant,
                     },
                 }
                 await conn.write(data, bucket=AUDIT_CREDENTIALS["bucket"])
             except (TypeError, AttributeError, ValueError, DriverError) as ex:
                 logger.error(f"InfluxDB: Error saving Audit Log: {ex}")
 
-    async def _log_to_document(self, answer, status, user):
+    async def _log_to_document(self, answer, status, user, *, tenant: str = None):
         """Insert the audit record as a document (e.g. MongoDB)."""
         from asyncdb.exceptions import DriverError
 
-        record = _build_record(answer, status, user, self.host)
+        record = _build_record(answer, status, user, self.host, tenant=tenant)
         async with await self._driver.connection() as conn:
             try:
                 await conn.insert(AUDIT_TABLE, record)
             except (TypeError, AttributeError, ValueError, DriverError) as ex:
                 logger.error(f"{self._backend}: Error saving Audit Log: {ex}")
 
-    async def _log_to_db(self, answer, status, user):
+    async def _log_to_db(self, answer, status, user, *, tenant: str = None):
         from asyncdb.exceptions import DriverError
 
-        record = _build_record(answer, status, user, self.host)
+        record = _build_record(answer, status, user, self.host, tenant=tenant)
         sql, values = build_insert(AUDIT_TABLE, record, self._paramstyle)
         async with await self._driver.connection() as conn:
             try:
                 await conn.execute(sql, *values)
             except (TypeError, AttributeError, ValueError, DriverError) as ex:
                 logger.error(f"{self._backend}: Error saving Audit Log: {ex}")
+
+    # ------------------------------------------------------------------
+    # Read / query API
+    # ------------------------------------------------------------------
+
+    async def query(
+        self,
+        *,
+        tenant: str,
+        user_id=None,
+        username: str = None,
+        status: str = None,
+        rule: str = None,
+        since: datetime = None,
+        until: datetime = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict]:
+        """Read audit entries back, **always** constrained to one ``tenant``.
+
+        Structured querying is implemented for SQL backends. For the
+        ``timeseries`` (influx), ``document`` and ``log`` families this returns
+        an empty list and logs a warning — query those stores directly.
+
+        Args:
+            tenant: Required tenant scope. Every returned row belongs to it.
+            user_id / username / status / rule: Optional equality filters.
+            since / until: Optional inclusive ``timestamp`` range bounds.
+            limit / offset: Pagination (``LIMIT``/``OFFSET``).
+
+        Returns:
+            A list of record dicts (newest first), or ``[]`` on any driver error
+            or unsupported backend (best-effort, consistent with the write side).
+        """
+        if tenant is None:
+            raise ValueError("AuditLog.query() requires a 'tenant' scope.")
+        if self._family != "sql":
+            logger.warning(
+                f"AuditLog.query() is only supported for SQL backends; "
+                f"backend '{self._backend}' ({self._family}) is write-only. "
+                f"Query the backing store directly."
+            )
+            return []
+        return await self._query_db(
+            tenant=tenant,
+            user_id=user_id,
+            username=username,
+            status=status,
+            rule=rule,
+            since=since,
+            until=until,
+            limit=limit,
+            offset=offset,
+        )
+
+    @staticmethod
+    def _build_conditions(
+        *, tenant, user_id, username, status, rule, since, until
+    ) -> list:
+        """Assemble the WHERE conditions for :meth:`query` (tenant always first)."""
+        conditions = [("tenant", "=", tenant)]
+        if user_id is not None:
+            conditions.append(("user_id", "=", user_id))
+        if username is not None:
+            conditions.append(("username", "=", username))
+        if status is not None:
+            conditions.append(("status", "=", status))
+        if rule is not None:
+            conditions.append(("rule", "=", rule))
+        if since is not None:
+            conditions.append(("timestamp", ">=", since))
+        if until is not None:
+            conditions.append(("timestamp", "<=", until))
+        return conditions
+
+    async def _query_db(
+        self, *, tenant, user_id, username, status, rule, since, until, limit, offset
+    ) -> list[dict]:
+        from asyncdb.exceptions import DriverError
+
+        conditions = self._build_conditions(
+            tenant=tenant,
+            user_id=user_id,
+            username=username,
+            status=status,
+            rule=rule,
+            since=since,
+            until=until,
+        )
+        sql, values = build_select(
+            AUDIT_TABLE,
+            conditions,
+            self._paramstyle,
+            order_by="timestamp",
+            descending=True,
+            limit=limit,
+            offset=offset,
+        )
+        async with await self._driver.connection() as conn:
+            try:
+                result = await conn.fetch_all(sql, *values)
+            except (TypeError, AttributeError, ValueError, DriverError) as ex:
+                logger.error(f"{self._backend}: Error querying Audit Log: {ex}")
+                return []
+        if not result:
+            return []
+        return [dict(row) for row in result]

--- a/sdd/specs/audit-log-tenant-and-query.spec.md
+++ b/sdd/specs/audit-log-tenant-and-query.spec.md
@@ -1,0 +1,148 @@
+---
+type: feature
+base_branch: dev
+---
+
+<!-- LANGUAGE: English only. -->
+
+# Feature Specification: Audit Log — Tenant Scoping & Query API
+
+**Feature**: audit-log-tenant-and-query
+**Branch**: `feat-audit-tenant-and-query` (off `dev`)
+**Date**: 2026-07-13
+**Author**: FieldSync team (with Jesús Lara's "reuse nav-auth audit log" direction)
+**Status**: draft
+
+> **Resume anchor.** This spec exists so the work survives a context compaction.
+> It captures the verified current state of `navigator_auth/abac/audit.py`, the
+> planned change, and how the downstream consumer (FieldSync FEAT-314) uses it.
+
+---
+
+## 1. Motivation
+
+FieldSync **FEAT-314 (Audit Trail & Compliance Log)** must reuse navigator-auth's
+audit log instead of building its own store (decision: Jesús Lara). A code review
+of the FieldSync implementation found two blockers that trace back to gaps in
+`navigator_auth.abac.audit.AuditLog`:
+
+1. **No tenant scoping.** `AuditLog` records have no `tenant`, and the `audit_log`
+   table has no tenant column — so a `GET /api/v1/audit` read cannot be constrained
+   to one tenant → cross-tenant audit/PII leak. (nav-auth already scopes *policies*
+   per tenant — see `sdd/specs/per-tenant-policy-scoping.spec.md`; audit should too.)
+2. **No read/query API.** `AuditLog` only writes (`log()`); it has no `query()`, so
+   consumers hand-roll raw reads. A tenant-scoped `query()` belongs in nav-auth.
+
+Adding both makes the audit log **multi-tenant and queryable** for every consumer,
+and lets FieldSync FEAT-314 drop its interim `compliance.audit_log` table and reuse
+nav-auth fully.
+
+---
+
+## 2. Current State (verified 2026-07-13, `navigator_auth/abac/audit.py` on `dev`)
+
+- Backend **families** (via `AUDIT_BACKEND`): `log` (logger), `timeseries`
+  (`influx`), `document` (`mongo`/`documentdb`), `sql` (any asyncdb driver +
+  `AUDIT_DSN`). Classified by `AuditLog._resolve_family()`.
+- Pure helpers: `resolve_paramstyle()`, `build_placeholders()`, `build_insert()`
+  (paramstyle-aware, unit-tested independently). `SQL_PARAMSTYLES` maps drivers →
+  dialect; `_PARAMSTYLE_RENDERERS` renders the n-th placeholder.
+- `_build_record(answer, status, user, host) -> dict` → columns: `timestamp,
+  environment, domain, host, status, message (=answer.response), rule, username,
+  user_id`. **No `tenant`.**
+- `async log(answer, status, user)` dispatches to `_log_to_logger` / `_log_to_influx`
+  / `_log_to_document` / `_log_to_db`. Writes are **best-effort** (driver errors are
+  caught + logged, never raised).
+- **No `query()` method exists.**
+- Settings (`navigator_auth/conf.py`): `ENABLE_AUDIT_LOG` (491), `AUDIT_BACKEND`
+  (498, default `influx`), `AUDIT_DSN` (510), `AUDIT_TABLE` (512, default `audit_log`),
+  `AUDIT_PARAMSTYLE` (519, default `format`), `AUDIT_CREDENTIALS` (522, = INFLUX creds).
+
+---
+
+## 3. Design / Changes (backwards-compatible)
+
+### 3.1 Tenant on writes
+- `_build_record(answer, status, user, host, *, tenant=None)` adds a `tenant` key.
+- `AuditLog.log(answer, status, user, *, tenant=None)` threads `tenant` to every
+  write path: logger (include in message), influx (tag), document (field), sql
+  (column). `tenant` is **optional** → existing PDP callers (`log(answer, status, user)`)
+  are unaffected.
+
+### 3.2 `tenant` column on the SQL audit table
+- The `AUDIT_TABLE` gains a `tenant` column. nav-auth does not own DDL/migrations;
+  document the required column + a suggested migration. Consumers (FieldSync) run it.
+  Index suggestion: `(tenant, timestamp DESC)`.
+
+### 3.3 New `query()` read API
+- `async AuditLog.query(*, tenant, user_id=None, username=None, status=None,
+  rule=None, since=None, until=None, limit=100, offset=0) -> list[dict]`.
+- **`tenant` is required** and always constrains the read.
+- Backend-aware, mirroring the write dispatch:
+  - `sql`: parameterised `SELECT ... WHERE tenant = ? [AND ...] ORDER BY timestamp DESC
+    LIMIT/OFFSET` — add a pure `build_select(table, filters, paramstyle, ...)` helper
+    (unit-testable like `build_insert`).
+  - `document`: `find({tenant, ...})` with limit/skip.
+  - `timeseries` (influx): tenant-tagged query.
+  - `log`: return `[]` (not queryable) + a warning.
+- Read errors are best-effort (catch driver errors, log, return `[]`) — consistent
+  with the write side.
+
+### 3.4 Tests
+- Extend the existing pure-helper tests: `build_select` + `build_placeholders` for all
+  paramstyles.
+- `_build_record` includes `tenant` when provided; `log(..., tenant=...)` round-trips.
+- `query()` filters by tenant (a fake driver asserts tenant is always in the WHERE),
+  pagination, unsupported backend (`log`) → `[]`.
+
+---
+
+## 4. Module Breakdown (candidate tasks)
+- **T1** — tenant on writes: `_build_record` + `log(*, tenant=None)` + 4 write paths + tests.
+- **T2** — `query()` + `build_select` helper + backend reads + tests.
+- **T3** — docs (`config.rst`, `changelog.rst`) + audit-table `tenant` DDL/migration note.
+
+---
+
+## 5. Downstream Consumption (FieldSync FEAT-314)
+- FieldSync uses nav-auth via editable source: uncomment
+  `navigator-auth = { path = "../navigator-auth", editable = true }` in fieldsync
+  `pyproject.toml [tool.uv.sources]` (do NOT commit) + `uv sync` in fieldsync's venv.
+- `apps/compliance/audit_log.py::AuditLogAdapter` then calls `log(..., tenant=...)`
+  and `query(tenant=...)`, and the interim `compliance.audit_log` own-table plan
+  (FieldSync `TASK-314-5`) is **dropped** in favour of nav-auth.
+- `GET /api/v1/audit` resolves tenant server-side (like `apps/claims _get_tenant`) and
+  passes it to `AuditLog.query(tenant=...)`.
+
+---
+
+## 6. Codebase Contract (anti-hallucination)
+```python
+# navigator_auth/abac/audit.py (dev):
+def _build_record(answer, status, user, host) -> dict          # add *, tenant=None
+def build_insert(table, record, paramstyle) -> tuple[str,list] # pattern for build_select
+def resolve_paramstyle(backend, default="format") -> str
+def build_placeholders(paramstyle, count) -> list[str]
+class AuditLog:
+    def __init__(self)                        # _backend/_family/_driver/_paramstyle
+    async def log(self, answer, status, user) # add *, tenant=None
+    # NO query() yet — this feature adds it
+# conf.py: AUDIT_BACKEND, AUDIT_DSN, AUDIT_TABLE, AUDIT_PARAMSTYLE, AUDIT_CREDENTIALS, ENABLE_AUDIT_LOG
+```
+### Does NOT exist
+- ~~`AuditLog.query()`~~ — added by this feature.
+- ~~`tenant` in `_build_record` / the audit table~~ — added by this feature.
+
+---
+
+## 7. Open / Coordination
+- **PR to `phenobarbital/navigator-auth` `dev`** — this is Jesús's platform library; needs his buy-in.
+- **Release + version bump** for non-editable consumers (FieldSync dev uses editable path meanwhile).
+- **Audit-table `tenant` migration** is ops-owned (nav-auth doesn't manage DDL).
+- Cross-ref: FieldSync `sdd/specs/audit-trail-compliance.spec.md` (FEAT-314) + its `TASK-314-5`
+  (review remediation) — the tenant fix there defers to THIS spec once landed.
+
+## Revision History
+| Version | Date | Author | Change |
+|---|---|---|---|
+| 0.1 | 2026-07-13 | FieldSync team | Initial spec (resume anchor): tenant scoping + `query()` on `AuditLog`, driven by FieldSync FEAT-314 review. |

--- a/sdd/specs/audit-log-tenant-and-query.spec.md
+++ b/sdd/specs/audit-log-tenant-and-query.spec.md
@@ -11,7 +11,7 @@ base_branch: dev
 **Branch**: `feat-audit-tenant-and-query` (off `dev`)
 **Date**: 2026-07-13
 **Author**: FieldSync team (with Jesús Lara's "reuse nav-auth audit log" direction)
-**Status**: draft
+**Status**: implemented (pending PR to `phenobarbital/navigator-auth` `dev` + Jesús's review)
 
 > **Resume anchor.** This spec exists so the work survives a context compaction.
 > It captures the verified current state of `navigator_auth/abac/audit.py`, the
@@ -78,15 +78,19 @@ nav-auth fully.
 - `async AuditLog.query(*, tenant, user_id=None, username=None, status=None,
   rule=None, since=None, until=None, limit=100, offset=0) -> list[dict]`.
 - **`tenant` is required** and always constrains the read.
-- Backend-aware, mirroring the write dispatch:
+- Backend-aware:
   - `sql`: parameterised `SELECT ... WHERE tenant = ? [AND ...] ORDER BY timestamp DESC
-    LIMIT/OFFSET` — add a pure `build_select(table, filters, paramstyle, ...)` helper
-    (unit-testable like `build_insert`).
-  - `document`: `find({tenant, ...})` with limit/skip.
-  - `timeseries` (influx): tenant-tagged query.
-  - `log`: return `[]` (not queryable) + a warning.
+    LIMIT/OFFSET` — via a pure `build_select(table, conditions, paramstyle, ...)` helper
+    (unit-testable like `build_insert`; conditions are `(column, operator, value)` triples).
+  - `document` / `timeseries` (influx) / `log`: **write-only through this API** — `query()`
+    logs a warning and returns `[]`. **Decision (impl):** structured reads are SQL-only for
+    now; the real consumer (FieldSync) uses Postgres, and shipping untested influx/mongo read
+    queries would violate the "backend-safe, degrade cleanly" requirement from the FEAT-314
+    review (Major 3). Query those stores directly if needed. The **write** path still supports
+    all four families (tenant as column/field/tag/message).
 - Read errors are best-effort (catch driver errors, log, return `[]`) — consistent
   with the write side.
+- `tenant=None` raises `ValueError` (a query can never span tenants).
 
 ### 3.4 Tests
 - Extend the existing pure-helper tests: `build_select` + `build_placeholders` for all
@@ -146,3 +150,4 @@ class AuditLog:
 | Version | Date | Author | Change |
 |---|---|---|---|
 | 0.1 | 2026-07-13 | FieldSync team | Initial spec (resume anchor): tenant scoping + `query()` on `AuditLog`, driven by FieldSync FEAT-314 review. |
+| 0.2 | 2026-07-13 | FieldSync team | **Implemented.** `tenant` on `_build_record`/`log()` across all 4 write families; `build_select()` helper; `AuditLog.query(*, tenant, ...)` SQL-only (other families degrade to `[]`+warning); docs (`documentation/audit-log.md`, `CHANGELOG.md`) + `tenant` DDL/migration + index. 34 unit tests pass (`tests/test_audit_backends.py`, incl. 18 new). Pending PR to Jesús's `dev`. |

--- a/tests/test_audit_backends.py
+++ b/tests/test_audit_backends.py
@@ -5,12 +5,18 @@ These cover the pure, driver-agnostic helpers used by
 various asyncdb SQL drivers. Driver I/O itself needs a live database and is
 exercised in integration tests, not here.
 """
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
 import pytest
 
 from navigator_auth.abac.audit import (
     build_placeholders,
     build_insert,
+    build_select,
     resolve_paramstyle,
+    _build_record,
+    AuditLog,
 )
 
 
@@ -79,3 +85,169 @@ def test_resolve_paramstyle_known(backend, expected):
 def test_resolve_paramstyle_unknown_uses_default():
     assert resolve_paramstyle("brand_new_driver", default="qmark") == "qmark"
     assert resolve_paramstyle("brand_new_driver", default="format") == "format"
+
+
+# ---------------------------------------------------------------------------
+# build_select (tenant-scoped read helper)
+# ---------------------------------------------------------------------------
+
+def test_build_select_numeric_with_conditions_and_pagination():
+    conditions = [("tenant", "=", "acme"), ("status", "=", "DENY")]
+    sql, values = build_select(
+        "audit_log", conditions, "numeric",
+        order_by="timestamp", descending=True, limit=50, offset=10,
+    )
+    assert sql == (
+        "SELECT * FROM audit_log WHERE tenant = $1 AND status = $2 "
+        "ORDER BY timestamp DESC LIMIT 50 OFFSET 10"
+    )
+    assert values == ["acme", "DENY"]
+
+
+def test_build_select_range_conditions_format():
+    since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    conditions = [("tenant", "=", "acme"), ("timestamp", ">=", since)]
+    sql, values = build_select("audit_log", conditions, "format", order_by="timestamp")
+    assert sql == (
+        "SELECT * FROM audit_log WHERE tenant = %s AND timestamp >= %s "
+        "ORDER BY timestamp DESC"
+    )
+    assert values == ["acme", since]
+
+
+def test_build_select_no_conditions_omits_where():
+    sql, values = build_select("audit_log", [], "numeric")
+    assert sql == "SELECT * FROM audit_log"
+    assert values == []
+
+
+def test_build_select_offset_zero_omitted_and_limit_coerced():
+    sql, _ = build_select(
+        "audit_log", [("tenant", "=", "acme")], "numeric",
+        order_by="timestamp", limit="25", offset=0,
+    )
+    # limit is coerced to int; offset=0 is falsy -> no OFFSET clause
+    assert sql.endswith("LIMIT 25")
+    assert "OFFSET" not in sql
+
+
+def test_build_select_ascending():
+    sql, _ = build_select(
+        "audit_log", [("tenant", "=", "acme")], "qmark",
+        order_by="timestamp", descending=False,
+    )
+    assert "ORDER BY timestamp ASC" in sql
+
+
+# ---------------------------------------------------------------------------
+# _build_record — tenant column
+# ---------------------------------------------------------------------------
+
+def _fake_answer(response="policy-x", rule="rule-1"):
+    return SimpleNamespace(response=response, rule=rule)
+
+
+def _fake_user(username="alice", user_id=42):
+    return SimpleNamespace(username=username, id=user_id)
+
+
+def test_build_record_includes_tenant_when_provided():
+    record = _build_record(
+        _fake_answer(), "ALLOW", _fake_user(), "127.0.0.1", tenant="acme"
+    )
+    assert record["tenant"] == "acme"
+    assert record["status"] == "ALLOW"
+    assert record["username"] == "alice"
+    assert record["user_id"] == 42
+
+
+def test_build_record_tenant_defaults_to_none():
+    record = _build_record(_fake_answer(), "DENY", _fake_user(), "127.0.0.1")
+    assert record["tenant"] is None
+
+
+# ---------------------------------------------------------------------------
+# AuditLog.query — tenant-scoped reads (fake driver, no live DB)
+# ---------------------------------------------------------------------------
+
+class _FakeConn:
+    def __init__(self, captured, rows):
+        self._captured = captured
+        self._rows = rows
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def fetch_all(self, sql, *values):
+        self._captured["sql"] = sql
+        self._captured["values"] = list(values)
+        return self._rows
+
+
+class _FakeDriver:
+    def __init__(self, captured, rows):
+        self._captured = captured
+        self._rows = rows
+
+    async def connection(self):
+        return _FakeConn(self._captured, self._rows)
+
+
+def _sql_audit_log(rows=None, captured=None):
+    """Build an AuditLog bypassing conf-driven __init__, wired to a fake SQL driver."""
+    captured = captured if captured is not None else {}
+    audit = AuditLog.__new__(AuditLog)
+    audit.host = "127.0.0.1"
+    audit._backend = "pg"
+    audit._family = "sql"
+    audit._paramstyle = "numeric"
+    audit._driver = _FakeDriver(captured, rows or [])
+    return audit, captured
+
+
+@pytest.mark.asyncio
+async def test_query_always_scopes_by_tenant():
+    rows = [{"tenant": "acme", "status": "ALLOW", "username": "alice"}]
+    audit, captured = _sql_audit_log(rows=rows)
+    result = await audit.query(tenant="acme")
+    # tenant is always the first WHERE predicate and its bound value
+    assert "WHERE tenant = $1" in captured["sql"]
+    assert captured["values"][0] == "acme"
+    assert result == rows
+
+
+@pytest.mark.asyncio
+async def test_query_appends_optional_filters():
+    audit, captured = _sql_audit_log()
+    await audit.query(tenant="acme", user_id=42, status="DENY")
+    assert captured["sql"].startswith(
+        "SELECT * FROM audit_log WHERE tenant = $1 AND user_id = $2 AND status = $3"
+    )
+    assert captured["values"] == ["acme", 42, "DENY"]
+
+
+@pytest.mark.asyncio
+async def test_query_pagination():
+    audit, captured = _sql_audit_log()
+    await audit.query(tenant="acme", limit=25, offset=50)
+    assert captured["sql"].endswith("ORDER BY timestamp DESC LIMIT 25 OFFSET 50")
+
+
+@pytest.mark.asyncio
+async def test_query_requires_tenant():
+    audit, _ = _sql_audit_log()
+    with pytest.raises(ValueError):
+        await audit.query(tenant=None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("family", ["log", "document", "timeseries"])
+async def test_query_unsupported_backend_returns_empty(family):
+    audit = AuditLog.__new__(AuditLog)
+    audit._backend = family
+    audit._family = family
+    result = await audit.query(tenant="acme")
+    assert result == []


### PR DESCRIPTION
## Summary

Adds **tenant scoping** and a **read/query API** to the ABAC/PBAC `AuditLog`
(`navigator_auth/abac/audit.py`). Motivated by a downstream consumer (FieldSync
FEAT-314) that needs to reuse this audit log instead of building its own store,
but can't because audit records have no tenant and there is no way to read them
back per tenant → a tenant-scoped read is impossible today.

Both additions are **backwards-compatible** — existing PDP callers
(`log(answer, status, user)`) are unaffected.

## Changes

- **`tenant` on writes** — `_build_record(...)` and `AuditLog.log(...)` gain an
  optional keyword-only `tenant`, threaded to all four write families:
  SQL column, document field, influx tag, logger message.
- **`AuditLog.query(*, tenant, user_id=None, username=None, status=None,
  rule=None, since=None, until=None, limit=100, offset=0)`** — reads entries
  back, **always** constrained to one `tenant` (`tenant=None` raises
  `ValueError`, so a query can never span tenants). Newest-first, paginated.
  - Structured querying is implemented for **SQL backends**. For `influx`,
    `mongo`/`documentdb` and `log` it logs a warning and returns `[]` (those
    stores stay write-only through this API — query them directly). This keeps
    the read path backend-safe rather than blindly issuing untested queries.
  - Reads are best-effort (driver errors caught/logged → `[]`), consistent with
    the write side.
- **`build_select(table, conditions, paramstyle, *, order_by, descending,
  limit, offset)`** — new pure helper mirroring `build_insert` (unit-tested, no
  live DB). Conditions are `(column, operator, value)` triples; values are
  always bound as placeholders, `LIMIT`/`OFFSET` inlined as coerced ints.
- **Audit table** gains a nullable `tenant` column + index
  `(tenant, timestamp DESC)`. DDL and an `ALTER TABLE` migration are documented;
  navigator-auth doesn't manage migrations, so the consuming service runs it.
- **Docs**: `documentation/audit-log.md` (record schema, tenant/query section,
  DDL + migration) and `CHANGELOG.md`.

## Testing

`tests/test_audit_backends.py` — **34 pass (18 new)**, no live DB required:

- `build_select` across all paramstyles, range/equality conditions, pagination,
  `LIMIT`/`OFFSET` coercion, ascending/descending.
- `_build_record` includes `tenant` when provided, `None` otherwise.
- `query()` via a fake SQL driver: tenant is always the first `WHERE` predicate
  and bound value; optional filters appended; pagination; `tenant=None` →
  `ValueError`; unsupported backends (`log`/`document`/`timeseries`) → `[]`.

## Notes for review

- The `tenant` migration is additive/nullable, so adopting it is non-breaking.
- Read support is intentionally SQL-only for now (the driving consumer uses
  Postgres). Extending `query()` to influx/mongo can follow if needed.
- Includes an SDD spec under `sdd/specs/audit-log-tenant-and-query.spec.md`
  documenting the design (matches the repo's existing `sdd/specs/` convention).

Targets `dev` per the spec's `base_branch`.
