### PR TITLE
feat(authz): add lookup_location (IP→lat/lon) via GeoLite2-City

### DIFF
--- a/navigator_auth/authorizations/_geoip.py
+++ b/navigator_auth/authorizations/_geoip.py
@@ -1,15 +1,27 @@
-"""Country geolocation via the MaxMind GeoLite2 database (optional).
+"""Geolocation via the MaxMind GeoLite2 databases (optional).
 
-The ``geoip2`` package and a GeoLite2-Country ``.mmdb`` file are only required
-when ``USERAGENT_SECURITY`` is enabled. The reader is opened lazily, once, and
-cached for the lifetime of the process. Any failure (missing package, missing
-database, lookup error) resolves to ``None`` so callers can *fail closed*.
+Two independent, lazily-opened readers:
+
+- **Country** (``GEOIP_DATABASE`` → GeoLite2-Country): :func:`lookup_country`
+  returns an ISO country code, used by ``USERAGENT_SECURITY`` geo-fencing.
+- **City** (``GEOIP_CITY_DATABASE`` → GeoLite2-City): :func:`lookup_location`
+  returns ``(latitude, longitude)``. Only the City database carries
+  coordinates. Used as a GPS-off fallback (cell/city granularity) — e.g.
+  stamping a punch's lat/lon when a client sends no GPS.
+
+The ``geoip2`` package and the ``.mmdb`` files are optional
+(``pip install navigator-auth[geoip]``). Any failure (missing package,
+missing database, lookup error) resolves to ``None`` so callers *fail
+closed* / degrade gracefully.
 """
 import logging
-from ..conf import GEOIP_DATABASE
+from ..conf import GEOIP_DATABASE, GEOIP_CITY_DATABASE
 
 _reader = None
 _loaded = False
+
+_city_reader = None
+_city_loaded = False
 
 
 def _load_reader():
@@ -51,9 +63,58 @@ def lookup_country(ip: str | None) -> str | None:
         return None
 
 
+def _load_city_reader():
+    """Open the GeoLite2-City reader once; return None if unavailable."""
+    global _city_reader, _city_loaded
+    _city_loaded = True
+    try:
+        import geoip2.database
+    except ImportError:
+        logging.warning(
+            "authz: IP geolocation requires the 'geoip2' package "
+            "(pip install navigator-auth[geoip]); lookup_location returns None."
+        )
+        return None
+    try:
+        _city_reader = geoip2.database.Reader(GEOIP_CITY_DATABASE)
+        logging.info(f"authz: GeoIP City database loaded from {GEOIP_CITY_DATABASE}")
+    except (FileNotFoundError, OSError, ValueError) as exc:
+        logging.warning(
+            f"authz: cannot open GeoIP City database '{GEOIP_CITY_DATABASE}': "
+            f"{exc}; lookup_location returns None."
+        )
+        _city_reader = None
+    return _city_reader
+
+
+def lookup_location(ip: str | None) -> tuple[float, float] | None:
+    """Return ``(latitude, longitude)`` for ``ip`` at city granularity, or None.
+
+    Uses the GeoLite2-City database (``GEOIP_CITY_DATABASE``) — distinct from the
+    country database used by :func:`lookup_country`, since only the City database
+    carries coordinates. Fail-safe: a missing package/database, an unknown
+    address, or an entry without coordinates all resolve to ``None`` so callers
+    degrade gracefully (e.g. store null coords rather than blocking a punch).
+    """
+    if not ip:
+        return None
+    if not _city_loaded:
+        _load_city_reader()
+    if _city_reader is None:
+        return None
+    try:
+        loc = _city_reader.city(ip).location
+        if loc is None or loc.latitude is None or loc.longitude is None:
+            return None
+        return (loc.latitude, loc.longitude)
+    except Exception as exc:  # noqa: BLE001 - AddressNotFound, ValueError, etc.
+        logging.debug(f"authz: GeoIP City lookup miss for {ip}: {exc}")
+        return None
+
+
 def reset_reader() -> None:
-    """Drop the cached reader (used by tests)."""
-    global _reader, _loaded
+    """Drop the cached readers (used by tests)."""
+    global _reader, _loaded, _city_reader, _city_loaded
     if _reader is not None:
         try:
             _reader.close()
@@ -61,3 +122,10 @@ def reset_reader() -> None:
             pass
     _reader = None
     _loaded = False
+    if _city_reader is not None:
+        try:
+            _city_reader.close()
+        except Exception:  # noqa: BLE001
+            pass
+    _city_reader = None
+    _city_loaded = False

--- a/navigator_auth/conf.py
+++ b/navigator_auth/conf.py
@@ -238,6 +238,16 @@ GEOIP_DATABASE = config.get(
     fallback="/etc/navigator/GeoLite2-Country.mmdb",
 )
 
+### Path to the MaxMind GeoLite2-City database (.mmdb) for IP->coordinate lookup.
+### Distinct from GEOIP_DATABASE (Country): only the City database carries
+### latitude/longitude. Used by ``authorizations._geoip.lookup_location`` as a
+### GPS-off fallback (cell/city granularity).
+GEOIP_CITY_DATABASE = config.get(
+    "GEOIP_CITY_DATABASE",
+    section="auth",
+    fallback="/etc/navigator/GeoLite2-City.mmdb",
+)
+
 ## Basic Authorization Middlewares
 AUTHORIZATION_MIDDLEWARES = ()
 


### PR DESCRIPTION
## What
Adds a **City-level IP geolocation** resolver alongside the existing country geo-fence.

- `_geoip.py`: new `lookup_location(ip) -> (lat, lon) | None` using a **separate, lazily-loaded GeoLite2-City reader** (`GEOIP_CITY_DATABASE`) — only the City database carries coordinates (the Country DB used by `lookup_country` does not). `reset_reader()` now drops the city reader too.
- `conf.py`: new `GEOIP_CITY_DATABASE` key (fallback `/etc/navigator/GeoLite2-City.mmdb`).
- No new dependency — `geoip2` is already the existing optional `[geoip]` extra.

## Fail-safe
Mirrors `lookup_country`: a missing `geoip2` package, a missing/unopenable `.mmdb`, an unknown address, or an entry without coordinates **all resolve to `None`** — callers degrade gracefully, never raise. Verified locally (no City DB present → `None`, no exception; `lookup_country` unchanged).

## Why
Consumed by **FieldSync FEAT-371** (rep clock-in/out): when a rep has no GPS, capture the public IP (via the existing `get_client_ip`) and stamp the punch's lat/lon at cell/city granularity. Per the architecture directive: *"reuse navigator-auth's authz geo-IP module — do not build a geolocator."* Until this lands, FieldSync's geoloc seam degrades to `None`.

## Ops note
Requires provisioning a `GeoLite2-City.mmdb` at `GEOIP_CITY_DATABASE` where navigator-auth runs (separate from the existing Country DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)