### PR TITLE
fix(templates): remove dead compile_templates step that crash-loops multi-worker servers

### DIFF
--- a/navigator_auth/templates.py
+++ b/navigator_auth/templates.py
@@ -45,17 +45,22 @@ class TemplateParser:
             searchpath=[str(self.path)]
         )
         # initialize the environment
+        #
+        # NOTE: templates are resolved at runtime via the FileSystemLoader
+        # below; the environment is never fed back a precompiled bytecode
+        # bundle (there is no ModuleLoader). A previous implementation called
+        # ``env.compile_templates(target=self.path/".compiled", zip="deflated")``
+        # here, which wrote an ~800 KB zip that nothing ever read. Worse, the
+        # target lived *inside* the loader's search path, so on any subsequent
+        # init the loader listed ``.compiled`` as a template and tried to read
+        # the binary zip as UTF-8 (UnicodeDecodeError); and under a multi-worker
+        # server (e.g. gunicorn -w N) the workers raced writing/reading that one
+        # shared file, tearing it mid-write. Both failures were re-raised
+        # fatally, crash-looping the process. The precompile step is pure dead
+        # work, so it is removed entirely.
         try:
-            # TODO: check the bug ,encoding='ANSI'
             self.env: Optional[Environment] = Environment(
                 loader=templateLoader, **self.config
-            )
-            # compiled_path = BytesIO()
-            compiled_path = str(
-                self.path.joinpath(".compiled")
-            )
-            self.env.compile_templates(
-                target=compiled_path, zip="deflated"
             )
         except Exception as err:
             raise RuntimeError(

--- a/navigator_auth/version.py
+++ b/navigator_auth/version.py
@@ -6,7 +6,7 @@ __title__ = "navigator_auth"
 __description__ = (
     "Navigator Auth is an Authentication/Authorization Toolkit for aiohttp."
 )
-__version__ = "0.22.10"  # pragma: no cover
+__version__ = "0.22.11"  # pragma: no cover
 __author__ = "Jesus Lara"
 __author_email__ = "jesuslarag@gmail.com"
 __copyright__ = "Copyright (c) 2019-2025 Jesus Lara"


### PR DESCRIPTION
## Problem

`TemplateParser.__init__` called `env.compile_templates(target=self.path/".compiled", zip="deflated")`, writing an ~800 KB Jinja bytecode zip on every construction. Nothing ever reads it back: the environment resolves templates at runtime via `FileSystemLoader` and there is no `ModuleLoader` consuming the bundle.

Beyond being dead work, it caused fatal boot crashes (both re-raised as `RuntimeError`, crash-looping the process):

1. **Self-inclusion** — the target lived *inside* the loader's search path, so on any later init `FileSystemLoader.list_templates()` returned `.compiled` as a template and tried to decode the binary zip as UTF-8 → `UnicodeDecodeError`.
2. **Multi-worker race** — under `gunicorn -w N`, workers raced writing/reading the single shared `.compiled`, tearing it mid-write → `UnicodeDecodeError` at a mid-file offset.

A single-process run never triggers either, so it only surfaced in deployment (observed on a 4-worker gunicorn staging pod).

## Fix

Remove the precompile step entirely. Template rendering is unchanged (runtime still uses `FileSystemLoader`); the wasted I/O and both crashes are gone.

## Verification

- `TemplateParser(directory=...)` builds successfully and no longer writes `.compiled`.
- `env.get_template("base.html")` still resolves.
- Version bumped `0.22.10 → 0.22.11`.