### PR TITLE
fix(decorators): type-guard _check_superuser groups membership; bind userinfo in allowed_groups

### DIFF
--- a/navigator_auth/decorators.py
+++ b/navigator_auth/decorators.py
@@ -244,8 +244,13 @@ def _check_superuser(userinfo: dict, user: object = None) -> bool:
     """
     if userinfo.get("superuser") is True or userinfo.get("is_superuser") is True:
         return True
-    if "groups" in userinfo:
-        if SUPERUSER_GROUP in userinfo["groups"]:
+    groups = userinfo.get("groups")
+    # Membership only on a real collection: `in` on a str is SUBSTRING
+    # matching, so an unguarded test would grant superuser to any value
+    # merely containing the word (e.g. groups="ex_superuser_revoked"),
+    # and raise TypeError on groups=None.
+    if isinstance(groups, (list, tuple, set, frozenset)):
+        if SUPERUSER_GROUP in groups:
             return True
     if user is not None and hasattr(user, "groups"):
         for g in user.groups:
@@ -385,7 +390,10 @@ def allowed_groups(groups: list, content_type: str = "application/json") -> Call
                 try:
                     userinfo = session[AUTH_SESSION_OBJECT]
                 except KeyError:
-                    member = False
+                    # `userinfo` must be bound: the check below dereferences it,
+                    # and an unbound name here turned a missing session object
+                    # into an UnboundLocalError (500) instead of a clean deny.
+                    userinfo = {}
                 if "groups" in userinfo:
                     member = bool(not set(userinfo["groups"]).isdisjoint(groups))
                 else:

--- a/tests/test_check_superuser.py
+++ b/tests/test_check_superuser.py
@@ -1,0 +1,55 @@
+"""Type-confusion tests for ``_check_superuser`` (decorators.py).
+
+``in`` is SUBSTRING matching on a str and membership only on a collection,
+so an unguarded ``SUPERUSER_GROUP in userinfo["groups"]`` grants superuser
+to any string value merely CONTAINING the word — e.g.
+``groups="ex_superuser_revoked"`` — and raises TypeError on ``groups=None``.
+These cases were found (and are equally guarded) downstream in fieldsync
+(Trocdigital/fieldsync#146).
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from navigator_auth.decorators import _check_superuser
+
+
+@pytest.mark.parametrize("hostile", [
+    "superuser",
+    "ex_superuser_revoked",
+    "ns_superuser_pending",
+    "not_a_superuser",
+])
+def test_string_groups_never_grants_superuser(hostile):
+    assert _check_superuser({"groups": hostile}) is False, (
+        f"groups={hostile!r} as a string must not grant superuser"
+    )
+
+
+@pytest.mark.parametrize("malformed", [None, 42, {"superuser": True}])
+def test_malformed_groups_denies_without_raising(malformed):
+    assert _check_superuser({"groups": malformed}) is False
+
+
+@pytest.mark.parametrize("groups, expected", [
+    (["superuser"], True),
+    (("superuser",), True),
+    ({"superuser"}, True),
+    (["editors"], False),
+    ([], False),
+])
+def test_collection_groups_resolve_normally(groups, expected):
+    assert _check_superuser({"groups": groups}) is expected
+
+
+@pytest.mark.parametrize("flag", ["superuser", "is_superuser"])
+def test_explicit_flag_still_wins(flag):
+    assert _check_superuser({flag: True, "groups": []}) is True
+
+
+def test_user_object_group_fallback_still_works():
+    group = MagicMock()
+    group.group = "superuser"
+    user = MagicMock()
+    user.groups = [group]
+    assert _check_superuser({}, user) is True


### PR DESCRIPTION
@phenobarbital — follow-up from the review discussion on Trocdigital/fieldsync#146, as offered there.

## `_check_superuser`: groups membership was substring matching

`in` is **substring matching on a `str`** and membership only on a collection, so the unguarded test at

```python
if "groups" in userinfo:
    if SUPERUSER_GROUP in userinfo["groups"]:
        return True
```

granted superuser to any string value merely *containing* the word — `{"groups": "ex_superuser_revoked"}` returned `True` — and raised an uncaught `TypeError` on `{"groups": None}` (a 500 from inside `is_superuser`). Membership is now tested only on a real collection (`list`/`tuple`/`set`/`frozenset`); any other shape denies. The explicit `superuser`/`is_superuser` flags and the user-object group fallback are unchanged.

`tests/test_check_superuser.py` pins the hostile strings, the malformed shapes (deny, don't raise), the collection shapes, the explicit flags, and the user-object fallback.

## `allowed_groups`: missing session object crashed instead of denying

The `except KeyError` branch set `member = False` but left `userinfo` unbound, so a session without `AUTH_SESSION_OBJECT` hit `if "groups" in userinfo:` and died with `UnboundLocalError` (500) instead of denying cleanly. It is now bound to `{}`, preserving the existing fallback flow.

Both cases were found while applying the same type guard downstream in fieldsync (Trocdigital/fieldsync#146); the parametrized tests port from there.
