### PR TITLE
Hotfix: user_session attaches session/user on bare-function handlers (v0.22.12)

### DIFF
--- a/navigator_auth/decorators.py
+++ b/navigator_auth/decorators.py
@@ -106,9 +106,17 @@ def user_session() -> Callable[[F], F]:
                 user = None
             if not user and request.get("user"):
                 user = request.get("user")
+            # Use middleware-attached user if available.
+            if not user and hasattr(request, "user") and request.user is not None:
+                user = request.user
             request["session"] = session
             _attach_vault_to_request(request, session)
-            if hasattr(args[0], "session"):
+            # Attach session and user to the request, as _method_wrapper does;
+            # a middleware-attached user must never be replaced with None.
+            request.session = session
+            if user is not None:
+                request.user = user
+            if args[0] is not request and hasattr(args[0], "session"):
                 args[0].session = session
                 args[0].user = user
             return await handler(*args, session=session, user=user, **kwargs)

--- a/navigator_auth/version.py
+++ b/navigator_auth/version.py
@@ -6,7 +6,7 @@ __title__ = "navigator_auth"
 __description__ = (
     "Navigator Auth is an Authentication/Authorization Toolkit for aiohttp."
 )
-__version__ = "0.22.11"  # pragma: no cover
+__version__ = "0.22.12"  # pragma: no cover
 __author__ = "Jesus Lara"
 __author_email__ = "jesuslarag@gmail.com"
 __copyright__ = "Copyright (c) 2019-2025 Jesus Lara"

--- a/tests/unit/test_user_session_decorator.py
+++ b/tests/unit/test_user_session_decorator.py
@@ -1,0 +1,137 @@
+"""Tests for @user_session attribute attachment on the bare-function path."""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from navigator_auth.decorators import user_session
+
+
+class FakeRequest:
+    """Minimal stand-in for web.Request: mapping access plus settable attributes."""
+
+    def __init__(self, data: dict = None):
+        self._data = dict(data or {})
+        self.method = "GET"
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __setitem__(self, key, value):
+        self._data[key] = value
+
+
+class FakeSession:
+    def __init__(self, user=None):
+        self._user = user
+
+    def decode(self, key):
+        if self._user is None:
+            raise RuntimeError("no user in session")
+        return self._user
+
+    def get(self, key, default=None):
+        return default
+
+
+def _patched(session):
+    return (
+        patch(
+            "navigator_auth.decorators.get_session",
+            new_callable=AsyncMock,
+            return_value=session,
+        ),
+        patch("navigator_auth.decorators._attach_vault_to_request"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_func_path_attaches_session_and_user_to_request():
+    """Bare-function handlers get request.session/request.user, like class views."""
+    session_user = object()
+    session = FakeSession(user=session_user)
+    request = FakeRequest()
+    get_sess, vault = _patched(session)
+
+    with get_sess, vault:
+        @user_session()
+        async def handler(request, session=None, user=None):
+            return "ok"
+
+        await handler(request)
+
+    assert request.session is session
+    assert request.user is session_user
+    assert request["session"] is session
+
+
+@pytest.mark.asyncio
+async def test_func_path_adopts_middleware_user_without_clobbering():
+    """A middleware-attached request.user survives when the session has no user."""
+    middleware_user = object()
+    session = FakeSession(user=None)
+    request = FakeRequest()
+    request.user = middleware_user
+    get_sess, vault = _patched(session)
+    received = {}
+
+    with get_sess, vault:
+        @user_session()
+        async def handler(request, session=None, user=None):
+            received["user"] = user
+            return "ok"
+
+        await handler(request)
+
+    assert request.user is middleware_user
+    assert received["user"] is middleware_user
+
+
+@pytest.mark.asyncio
+async def test_func_path_never_writes_none_user():
+    """With no user anywhere, request.user is left unset rather than set to None."""
+    session = FakeSession(user=None)
+    request = FakeRequest()
+    get_sess, vault = _patched(session)
+    received = {}
+
+    with get_sess, vault:
+        @user_session()
+        async def handler(request, session=None, user=None):
+            received["user"] = user
+            return "ok"
+
+        await handler(request)
+
+    assert not hasattr(request, "user")
+    assert request.session is session
+    assert received["user"] is None
+
+
+@pytest.mark.asyncio
+async def test_func_path_still_attaches_to_view_like_first_arg():
+    """When args[0] is a view-like instance, it keeps receiving session/user."""
+
+    class ViewLike:
+        session = None
+        user = None
+
+    view = ViewLike()
+    session_user = object()
+    session = FakeSession(user=session_user)
+    request = FakeRequest()
+    get_sess, vault = _patched(session)
+
+    with get_sess, vault:
+        @user_session()
+        async def handler(self, request, session=None, user=None):
+            return "ok"
+
+        await handler(view, request)
+
+    assert view.session is session
+    assert view.user is session_user
+    assert request.session is session
+    assert request.user is session_user


### PR DESCRIPTION
## Summary
- The `hasattr(args[0], "session")` guard introduced in d1d143c required `request.session` to exist before creating it, so function-based handlers decorated with `@user_session()` never got `request.session` / `request.user` attributes (only the kwargs).
- The bare-function path now mirrors `_method_wrapper`: it attaches `request.session` and `request.user` on the resolved request, adopts a middleware-attached user when the session decodes none, and never replaces a middleware-attached `request.user` with `None`.
- View-like first arguments (`args[0]` not being the request) keep receiving `session`/`user` as before.
- Version bump to 0.22.12 (hotfix).

## Test plan
- New `tests/unit/test_user_session_decorator.py` (4 tests): attribute attachment on the function path, middleware-user adoption without clobbering, no `None` overwrite, view-like `args[0]` compatibility.
- Existing decorator/vault wiring tests pass; remaining unit-suite failures (`test_strategies`, vault view/migrations/session_vault, `test_key_rotation` hang) are pre-existing on `dev` and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)