### PR TITLE
Add OAuth2 3LO example and fix session binding for access tokens

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,90 @@
+# navigator-auth examples
+
+## `oauth2_3lo_server.py` — end-to-end OAuth2 3LO (Authorization Code + PKCE)
+
+A single aiohttp application that plays all three OAuth2 roles at once, so the
+whole three-legged flow can be walked through in one browser tab:
+
+| Role | What provides it |
+|---|---|
+| Authorization Server | `navigator_auth.backends.oauth2.Oauth2Provider` (`/oauth2/*`) |
+| Client application | the SPA at `/` (`static/oauth2_3lo_app.html`) |
+| Resource Server | `GET /api/v1/me`, protected with `@is_authenticated()` + `@user_session()` |
+
+### Run it
+
+```bash
+mkdir -p env/dev && touch env/dev/.env   # navconfig needs this once
+redis-server --daemonize yes             # sessions are stored in Redis
+python examples/oauth2_3lo_server.py     # from the repository root
+```
+
+Open <http://localhost:5000/> and press **Start OAuth2 login**.
+Demo credentials: `demo` / `demo123` (or `alice` / `alice123`).
+
+> Run it from the repository root: the OAuth2 login and consent pages are
+> rendered from `templates/oauth/`, which `TemplateParser` resolves relative to
+> the project directory.
+
+### What the page walks you through
+
+1. **PKCE** — the SPA generates a `code_verifier` and its S256 `code_challenge`.
+2. **Authorize** — the browser goes to `/oauth2/authorize`, which redirects to
+   `/oauth2/login`, then to `/oauth2/consent`.
+3. **Callback** — navigator-auth redirects back to `/callback?code=…&state=…`.
+4. **Token** — the SPA `POST`s to `/oauth2/token` with the `code_verifier`, and
+   gets an access token (a JWT), a refresh token and the granted scope.
+5. **Resource** — it calls `GET /api/v1/me` with `Authorization: Bearer …`.
+
+It also exercises `/oauth2/userinfo`, the `refresh_token` grant (with rotation)
+and the consent grants API (`/api/v1/oauth2/grants`) — revoke the grant and the
+next login asks for consent again.
+
+### How an access token authenticates a request
+
+navigator-auth resolves the current user from a **server-side session**, not
+from the JWT alone. So when the OAuth2 provider issues a 3LO access token it
+also creates (or reuses) the resource owner's session and puts `session_id` and
+the user identity in the token claims. `AuthHandler.auth_middleware` then:
+
+1. decodes the bearer JWT,
+2. checks the token's `jti` was not revoked (RFC 7009),
+3. loads the session the claims point at,
+4. attaches the user to the request.
+
+`@is_authenticated()` gates on that, and `@user_session()` injects the `session`
+and `user` objects into the handler.
+
+### Example-only shortcuts
+
+Two things are stubbed so the example runs with nothing but Redis. **Drop both
+in a real deployment.**
+
+* `AuthHandler(enable_authdb=False)` — no PostgreSQL `authdb` pool.
+* `DemoIdentityProvider` — an in-memory user directory replacing `auth.users`.
+  Only the three database lookups are overridden; password hashing, token
+  creation and token decoding are the real `IdentityProvider`.
+
+OAuth2 clients likewise live in memory (`OAUTH2_CLIENT_STORAGE=memory`); the
+production default is `postgres` (see `navigator_auth/backends/oauth2/ddl.sql`).
+
+Everything else — code issuance and single use, PKCE verification, consent and
+consent-skip, refresh-token rotation with reuse detection, revocation — is the
+real implementation.
+
+---
+
+## `oauth2_server.py` — OAuth2 client registrations reference
+
+Registers the four demo clients (public, confidential, device, resource-server)
+and prints the endpoint contracts for the 3LO, Device Grant (RFC 8628) and
+Token Introspection (RFC 7662) flows. Use it as a reference for the raw
+requests; use `oauth2_3lo_server.py` for a flow you can actually click through.
+
+## Other examples
+
+| File | What it shows |
+|---|---|
+| `policy_server.py` | ABAC policy server |
+| `test_abac.py`, `test_policies.py` | ABAC policies and evaluation |
+| `test_decorators.py`, `test_handler.py` | auth decorators and handlers |

--- a/examples/oauth2_3lo_server.py
+++ b/examples/oauth2_3lo_server.py
@@ -1,0 +1,265 @@
+"""End-to-end OAuth2 Authorization-Code + PKCE (3LO) example.
+
+A single aiohttp application that plays all three roles of the flow, so the
+whole thing can be exercised from one browser tab without any external
+infrastructure other than Redis (used for the session storage):
+
+  * **Authorization Server** — ``navigator_auth``'s ``Oauth2Provider`` mounts
+    ``/oauth2/authorize``, ``/oauth2/login``, ``/oauth2/consent``,
+    ``/oauth2/token``, ``/oauth2/userinfo``, ``/oauth2/revoke``, ...
+  * **Client application** — the HTML/JS single-page app served at ``/``
+    (``examples/static/oauth2_3lo_app.html``). It generates the PKCE pair,
+    sends the browser to ``/oauth2/authorize`` and exchanges the returned
+    code at ``/oauth2/token``.
+  * **Resource Server** — ``GET /api/v1/me``, a plain aiohttp handler
+    protected with ``@is_authenticated()`` + ``@user_session()``. This is the
+    endpoint the example calls with the ``Authorization: Bearer <token>``
+    header once the code exchange succeeded.
+
+Run it **from the repository root**::
+
+    mkdir -p env/dev && touch env/dev/.env      # navconfig needs this once
+    redis-server --daemonize yes                # sessions live in Redis
+    python examples/oauth2_3lo_server.py
+
+then open http://localhost:5000/ and press *Start OAuth2 login*.
+Demo credentials: ``demo`` / ``demo123`` (see ``DEMO_USERS`` below).
+
+The working directory matters: the login and consent pages are rendered by
+``TemplateParser`` from ``<project>/templates/oauth/``.
+
+Notes
+-----
+* ``enable_authdb=False`` keeps the example free of PostgreSQL: OAuth2
+  clients live in memory (``OAUTH2_CLIENT_STORAGE=memory``) and users come
+  from :class:`DemoIdentityProvider` instead of ``auth.users``. A real
+  deployment drops both and uses the database-backed defaults.
+* Everything else — code issuance, PKCE verification, consent, refresh
+  tokens, the JWT access token and the session it is bound to — is the real
+  ``navigator_auth`` implementation.
+"""
+import os
+
+# ---------------------------------------------------------------------------
+# Environment MUST be set before navconfig / navigator_auth get imported.
+# ---------------------------------------------------------------------------
+os.environ.setdefault(
+    "AUTHENTICATION_BACKENDS",
+    "navigator_auth.backends.oauth2.Oauth2Provider",
+)
+# Keep OAuth2 clients in memory: no auth.clients table needed.
+os.environ.setdefault("OAUTH2_CLIENT_STORAGE", "memory")
+# Short-lived access tokens make the example easier to reason about.
+os.environ.setdefault("OAUTH_ACCESS_TOKEN_TTL", "900")
+os.environ.setdefault("AUTH_SECRET_KEY", "example-only-secret-key-change-me")
+
+import logging  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+from aiohttp import web  # noqa: E402
+
+from navigator_auth import AuthHandler  # noqa: E402
+from navigator_auth.backends.idp import IdentityProvider  # noqa: E402
+from navigator_auth.conf import AUTH_EXCLUDE_LIST_KEY  # noqa: E402
+from navigator_auth.decorators import is_authenticated, user_session  # noqa: E402
+from navigator_auth.exceptions import UserNotFound  # noqa: E402
+from navigator_auth.models import User  # noqa: E402
+
+
+HERE = Path(__file__).parent
+STATIC_DIR = HERE / "static"
+
+HOST = os.getenv("EXAMPLE_HOST", "localhost")
+PORT = int(os.getenv("EXAMPLE_PORT", "5000"))
+BASE_URL = f"http://{HOST}:{PORT}"
+
+#: The public (PKCE) client the SPA authenticates as.
+CLIENT_ID = "nav_example_spa"
+REDIRECT_URI = f"{BASE_URL}/callback"
+SCOPES = "default profile email offline_access"
+
+
+# ---------------------------------------------------------------------------
+# Demo user directory (replaces the auth.users table for this example)
+# ---------------------------------------------------------------------------
+
+DEMO_USERS = [
+    {
+        "user_id": 1,
+        "username": "demo",
+        "password": "demo123",
+        "first_name": "Demo",
+        "last_name": "User",
+        "email": "demo@example.com",
+    },
+    {
+        "user_id": 2,
+        "username": "alice",
+        "password": "alice123",
+        "first_name": "Alice",
+        "last_name": "Liddell",
+        "email": "alice@example.com",
+    },
+]
+
+
+class DemoIdentityProvider(IdentityProvider):
+    """In-memory :class:`IdentityProvider` for the example.
+
+    Only the three database-bound lookups are overridden; password hashing and
+    verification, token creation and token decoding all come from the real
+    ``IdentityProvider``.
+    """
+
+    def __init__(self, users: list[dict]):
+        super().__init__()
+        self._users: dict[str, User] = {}
+        for entry in users:
+            data = dict(entry)
+            raw_password = data.pop("password")
+            user = User(
+                **data,
+                display_name=f"{data['first_name']} {data['last_name']}",
+                is_active=True,
+                is_superuser=False,
+            )
+            # store the password the same way navigator-auth does in the DB
+            user.password = self.set_password(raw_password)
+            self._users[user.username] = user
+
+    async def get_user(self, login: str):
+        try:
+            return self._users[str(login)]
+        except KeyError as exc:
+            raise UserNotFound(f"Invalid Credentials for {login!r}") from exc
+
+    async def user_from_id(self, uid):
+        for user in self._users.values():
+            if str(user.user_id) == str(uid):
+                return user
+        raise UserNotFound(f"Invalid Credentials for user_id={uid!r}")
+
+
+# ---------------------------------------------------------------------------
+# Application handlers
+# ---------------------------------------------------------------------------
+
+async def index(request: web.Request) -> web.StreamResponse:
+    """Serve the single-page client application (also handles /callback)."""
+    return web.FileResponse(STATIC_DIR / "oauth2_3lo_app.html")
+
+
+async def client_config(request: web.Request) -> web.StreamResponse:
+    """Expose the OAuth2 client registration to the SPA.
+
+    A real client ships these values in its own configuration; the example
+    serves them so the HTML page has no hard-coded copy to drift out of sync.
+    """
+    return web.json_response(
+        {
+            "client_id": CLIENT_ID,
+            "redirect_uri": REDIRECT_URI,
+            "scope": SCOPES,
+            "authorization_endpoint": "/oauth2/authorize",
+            "token_endpoint": "/oauth2/token",
+            "userinfo_endpoint": "/oauth2/userinfo",
+            "revocation_endpoint": "/oauth2/revoke",
+            "protected_endpoint": "/api/v1/me",
+            "demo_users": [
+                {"username": u["username"], "password": u["password"]}
+                for u in DEMO_USERS
+            ],
+        }
+    )
+
+
+@is_authenticated()
+@user_session()
+async def me(request: web.Request, *, session=None, user=None) -> web.StreamResponse:
+    """The protected resource this example is really about.
+
+    Reached with ``Authorization: Bearer <access_token>``:
+
+    * ``@is_authenticated()`` rejects the request (401) when the bearer token
+      is missing, expired, revoked or does not resolve to a session.
+    * ``@user_session()`` injects the ``session`` and ``user`` objects that
+      the OAuth2 token is bound to.
+    """
+    userdata = request.get("userdata") or {}
+    return web.json_response(
+        {
+            "message": f"Hello {getattr(user, 'username', 'anonymous')}!",
+            "user": {
+                "user_id": getattr(user, "user_id", None) or getattr(user, "id", None),
+                "username": getattr(user, "username", None),
+                "email": getattr(user, "email", None),
+                "first_name": getattr(user, "first_name", None),
+                "last_name": getattr(user, "last_name", None),
+            },
+            "session_id": getattr(session, "session_id", None),
+            "token_claims": {
+                "client_id": userdata.get("client_id"),
+                "scope": userdata.get("scope"),
+                "jti": userdata.get("jti"),
+                "aud": userdata.get("aud"),
+            },
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Application factory
+# ---------------------------------------------------------------------------
+
+def make_app() -> web.Application:
+    app = web.Application()
+
+    # No PostgreSQL for this example: memory client storage + demo IdP.
+    auth = AuthHandler(enable_authdb=False)
+
+    demo_idp = DemoIdentityProvider(DEMO_USERS)
+    auth._idp = demo_idp
+    for backend in auth.backends.values():
+        backend._idp = demo_idp
+
+    auth.setup(app)
+
+    app.router.add_static("/static/", path=STATIC_DIR, name="static")
+    app.router.add_get("/", index, name="index")
+    app.router.add_get("/callback", index, name="callback")
+    app.router.add_get("/client-config", client_config, name="client_config")
+    app.router.add_get("/api/v1/me", me, name="me")
+
+    # The SPA shell and its configuration are public; /api/v1/me is not.
+    app[AUTH_EXCLUDE_LIST_KEY].extend(["/", "/callback", "/client-config"])
+
+    app.on_startup.append(register_demo_clients)
+    return app
+
+
+async def register_demo_clients(app: web.Application) -> None:
+    """Register the example OAuth2 clients in the in-memory client storage."""
+    from navigator_auth.backends.oauth2.models import OAuthClient
+
+    provider = app["auth"].backends["Oauth2Provider"]
+    spa_client = OAuthClient(
+        client_id=CLIENT_ID,
+        client_pk=None,
+        client_name="Navigator OAuth2 Example (SPA)",
+        client_secret=None,          # public client -> PKCE S256 required
+        client_type="public",
+        redirect_uris=[REDIRECT_URI],
+        policy_uri="",
+        client_logo_uri="",
+        default_scopes=["default", "profile", "email", "offline_access"],
+        allowed_grant_types=["authorization_code", "refresh_token"],
+    )
+    await provider.client_storage.save_client(spa_client)
+    logging.info("OAuth2 example: registered client %r", spa_client.client_id)
+    print(f"\n  Open {BASE_URL}/ and press 'Start OAuth2 login'.")
+    print("  Demo credentials: demo / demo123\n")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    web.run_app(make_app(), host=HOST, port=PORT)

--- a/examples/oauth2_server.py
+++ b/examples/oauth2_server.py
@@ -12,6 +12,10 @@ FEAT-093 + FEAT-094 production-grade demonstration:
   - RFC 8628 Device Authorization Grant (nav_device_client — public, S256 PKCE required).
   - RFC 7662 Token Introspection (nav_resource_server — confidential).
 
+For a *runnable* browser walk-through of the 3LO flow (PKCE, consent, token
+exchange and a protected endpoint) see ``examples/oauth2_3lo_server.py``; this
+file focuses on the client registrations and the raw endpoint contracts.
+
 Run with:
     python examples/oauth2_server.py
 
@@ -22,9 +26,13 @@ Device Grant flow described below.
 import os
 
 # Set Environment Variables BEFORE importing navigator_auth or navconfig
-os.environ["NAV_AUTHENTICATION_BACKENDS"] = "navigator_auth.backends.oauth2.Oauth2Provider"
-os.environ["NAV_OAUTH2_CLIENT_STORAGE"] = "memory"
-os.environ["NAV_API_HOST"] = "localhost"
+# navconfig reads these names verbatim -- the old "NAV_" prefix was never
+# looked up, so the app started with zero authentication backends.
+os.environ.setdefault(
+    "AUTHENTICATION_BACKENDS", "navigator_auth.backends.oauth2.Oauth2Provider"
+)
+os.environ.setdefault("OAUTH2_CLIENT_STORAGE", "memory")
+os.environ.setdefault("API_HOST", "localhost")
 
 import logging
 from aiohttp import web

--- a/examples/static/callback.html
+++ b/examples/static/callback.html
@@ -31,7 +31,7 @@
             const formData = new URLSearchParams();
             formData.append('grant_type', 'authorization_code');
             formData.append('code', code);
-            formData.append('client_id', '1');
+            formData.append('client_id', 'nav_public_client');
             formData.append('redirect_uri', 'http://localhost:5000/static/callback.html');
 
             try {

--- a/examples/static/oauth2_3lo_app.html
+++ b/examples/static/oauth2_3lo_app.html
@@ -1,0 +1,362 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>navigator-auth · OAuth2 3LO example</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+            --bg: #f4f6fb;
+            --card: #ffffff;
+            --ink: #1f2430;
+            --muted: #6b7280;
+            --line: #e3e7ef;
+            --accent: #1a73e8;
+            --ok: #157347;
+            --err: #b02a37;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #14161c;
+                --card: #1d212b;
+                --ink: #e8eaf0;
+                --muted: #9aa2b1;
+                --line: #2c3140;
+            }
+        }
+
+        * { box-sizing: border-box; }
+
+        body {
+            margin: 0;
+            padding: 2rem 1rem 4rem;
+            background: var(--bg);
+            color: var(--ink);
+            font: 15px/1.6 system-ui, -apple-system, "Segoe UI", sans-serif;
+        }
+
+        main { max-width: 820px; margin: 0 auto; }
+
+        h1 { font-size: 1.6rem; margin: 0 0 .25rem; }
+
+        .lede { color: var(--muted); margin: 0 0 2rem; }
+
+        section {
+            background: var(--card);
+            border: 1px solid var(--line);
+            border-radius: 10px;
+            padding: 1.25rem 1.5rem;
+            margin-bottom: 1.25rem;
+        }
+
+        h2 {
+            font-size: .8rem;
+            text-transform: uppercase;
+            letter-spacing: .08em;
+            color: var(--muted);
+            margin: 0 0 .75rem;
+        }
+
+        button {
+            font: inherit;
+            font-weight: 600;
+            padding: .55rem 1.1rem;
+            border: 0;
+            border-radius: 6px;
+            background: var(--accent);
+            color: #fff;
+            cursor: pointer;
+        }
+
+        button.secondary { background: #6b7280; }
+        button:disabled { opacity: .45; cursor: not-allowed; }
+
+        .row { display: flex; gap: .6rem; flex-wrap: wrap; align-items: center; }
+
+        pre {
+            background: rgba(127, 127, 127, .12);
+            border-radius: 6px;
+            padding: .8rem 1rem;
+            overflow-x: auto;
+            font-size: 13px;
+            margin: .6rem 0 0;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+
+        dl { display: grid; grid-template-columns: max-content 1fr; gap: .35rem 1rem; margin: 0; }
+        dt { color: var(--muted); }
+        dd { margin: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; word-break: break-all; }
+
+        .status { font-weight: 600; }
+        .status.ok { color: var(--ok); }
+        .status.err { color: var(--err); }
+
+        ol { margin: 0; padding-left: 1.2rem; color: var(--muted); }
+        ol strong { color: var(--ink); }
+        code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    </style>
+</head>
+
+<body>
+    <main>
+        <h1>navigator-auth · OAuth2 3LO</h1>
+        <p class="lede">
+            Authorization Code + PKCE against this same aiohttp server, then one
+            call to <code>GET /api/v1/me</code> — an endpoint protected with
+            <code>@is_authenticated()</code> and <code>@user_session()</code>.
+        </p>
+
+        <section>
+            <h2>The flow</h2>
+            <ol>
+                <li><strong>PKCE</strong> — the page generates a <code>code_verifier</code> and its S256 <code>code_challenge</code>.</li>
+                <li><strong>Authorize</strong> — the browser goes to <code>/oauth2/authorize</code>, logs in and approves the consent screen.</li>
+                <li><strong>Callback</strong> — navigator-auth redirects back here with <code>?code=…&amp;state=…</code>.</li>
+                <li><strong>Token</strong> — the page exchanges the code at <code>/oauth2/token</code> with the <code>code_verifier</code>.</li>
+                <li><strong>Resource</strong> — it calls <code>/api/v1/me</code> with <code>Authorization: Bearer …</code>.</li>
+            </ol>
+        </section>
+
+        <section>
+            <h2>1 · Login</h2>
+            <div class="row">
+                <button id="start">Start OAuth2 login</button>
+                <button id="reset" class="secondary">Reset</button>
+                <span id="login-status" class="status"></span>
+            </div>
+            <p id="creds" class="lede" style="margin:.9rem 0 0"></p>
+        </section>
+
+        <section>
+            <h2>2 · Token</h2>
+            <dl id="token-view"><dt>state</dt><dd id="tk-state">no token yet</dd></dl>
+            <pre id="token-raw" hidden></pre>
+        </section>
+
+        <section>
+            <h2>3 · Protected resource — <code>GET /api/v1/me</code></h2>
+            <div class="row">
+                <button id="call-me" disabled>Call /api/v1/me</button>
+                <button id="call-me-anon" class="secondary">Call it without credentials (expect 401)</button>
+                <button id="call-userinfo" class="secondary" disabled>Call /oauth2/userinfo</button>
+                <button id="refresh" class="secondary" disabled>Refresh token</button>
+                <span id="api-status" class="status"></span>
+            </div>
+            <pre id="api-out">—</pre>
+        </section>
+
+        <section>
+            <h2>4 · Consent grants — <code>/api/v1/oauth2/grants</code></h2>
+            <p class="lede" style="margin:0 0 .8rem">
+                navigator-auth remembers the consent you gave, so a second login
+                skips the approval screen. Revoke the grant to see it again.
+            </p>
+            <div class="row">
+                <button id="list-grants" class="secondary" disabled>List my grants</button>
+                <button id="revoke-grant" class="secondary" disabled>Revoke this app's grant</button>
+            </div>
+        </section>
+    </main>
+
+    <script>
+        const STORE = 'nav_oauth2_example';
+        let cfg = null;
+
+        // ---------- small helpers -------------------------------------------------
+        const $ = (id) => document.getElementById(id);
+
+        function b64url(bytes) {
+            return btoa(String.fromCharCode(...new Uint8Array(bytes)))
+                .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        }
+
+        function randomString(size = 32) {
+            return b64url(crypto.getRandomValues(new Uint8Array(size)));
+        }
+
+        async function s256(verifier) {
+            const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+            return b64url(digest);
+        }
+
+        const load = () => { try { return JSON.parse(sessionStorage.getItem(STORE)) || {}; } catch { return {}; } };
+        const save = (patch) => sessionStorage.setItem(STORE, JSON.stringify({ ...load(), ...patch }));
+        const clear = () => sessionStorage.removeItem(STORE);
+
+        function setStatus(el, text, ok) {
+            el.textContent = text;
+            el.className = 'status' + (ok === true ? ' ok' : ok === false ? ' err' : '');
+        }
+
+        function show(obj) {
+            $('api-out').textContent = typeof obj === 'string' ? obj : JSON.stringify(obj, null, 2);
+        }
+
+        // ---------- flow ----------------------------------------------------------
+        async function startLogin() {
+            const verifier = randomString(32);
+            const state = randomString(12);
+            save({ verifier, state });
+            const params = new URLSearchParams({
+                response_type: 'code',
+                client_id: cfg.client_id,
+                redirect_uri: cfg.redirect_uri,
+                scope: cfg.scope,
+                state,
+                code_challenge: await s256(verifier),
+                code_challenge_method: 'S256',
+            });
+            window.location.href = `${cfg.authorization_endpoint}?${params}`;
+        }
+
+        async function exchangeCode(code, state) {
+            const saved = load();
+            if (!saved.state || saved.state !== state) {
+                throw new Error('state mismatch — possible CSRF, aborting the exchange');
+            }
+            const body = new URLSearchParams({
+                grant_type: 'authorization_code',
+                code,
+                client_id: cfg.client_id,
+                redirect_uri: cfg.redirect_uri,
+                code_verifier: saved.verifier,   // PKCE proof
+            });
+            const res = await fetch(cfg.token_endpoint, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body,
+            });
+            const data = await res.json();
+            if (!res.ok) {
+                throw new Error(`${data.error || res.status}: ${data.error_description || ''}`);
+            }
+            save({ token: data });
+            return data;
+        }
+
+        async function refreshToken() {
+            const { token } = load();
+            const body = new URLSearchParams({
+                grant_type: 'refresh_token',
+                refresh_token: token.refresh_token,
+                client_id: cfg.client_id,
+            });
+            const res = await fetch(cfg.token_endpoint, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body,
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error_description || data.error || res.status);
+            save({ token: data });
+            renderToken(data);
+            setStatus($('api-status'), 'token refreshed (rotated)', true);
+            show(data);
+        }
+
+        async function callApi(url, withToken) {
+            const headers = {};
+            if (withToken) {
+                const { token } = load();
+                headers.Authorization = `${token.token_type} ${token.access_token}`;
+            }
+            // credentials:'omit' -> the browser session cookie left over from the
+            // consent screen is NOT sent, so "without the token" really means
+            // unauthenticated and returns 401 instead of falling back to it.
+            const res = await fetch(url, { headers, credentials: 'omit' });
+            const text = await res.text();
+            let parsed;
+            try { parsed = JSON.parse(text); } catch { parsed = text; }
+            setStatus($('api-status'), `${res.status} ${res.statusText}`, res.ok);
+            show(parsed);
+        }
+
+        // ---------- rendering -----------------------------------------------------
+        function renderToken(token) {
+            const view = $('token-view');
+            if (!token) {
+                view.innerHTML = '<dt>state</dt><dd id="tk-state">no token yet</dd>';
+                $('token-raw').hidden = true;
+                return;
+            }
+            const claims = JSON.parse(atob(token.access_token.split('.')[1]
+                .replace(/-/g, '+').replace(/_/g, '/')));
+            const rows = {
+                token_type: token.token_type,
+                expires_in: `${token.expires_in}s`,
+                scope: token.scope,
+                refresh_token: token.refresh_token ? `${token.refresh_token.slice(0, 12)}…` : '(none)',
+                'claims.user_id': claims.user_id,
+                'claims.client_id': claims.client_id,
+                'claims.aud': claims.aud,
+                'claims.jti': claims.jti,
+                'claims.session_id': claims.session_id,
+            };
+            view.innerHTML = Object.entries(rows)
+                .map(([k, v]) => `<dt>${k}</dt><dd>${v ?? '—'}</dd>`).join('');
+            const raw = $('token-raw');
+            raw.hidden = false;
+            raw.textContent = `access_token = ${token.access_token}`;
+            for (const id of ['call-me', 'call-userinfo', 'list-grants', 'revoke-grant']) {
+                $(id).disabled = false;
+            }
+            $('refresh').disabled = !token.refresh_token;
+        }
+
+        // ---------- boot ----------------------------------------------------------
+        (async function init() {
+            cfg = await (await fetch('/client-config')).json();
+            $('creds').textContent =
+                'Demo credentials: ' + cfg.demo_users.map(u => `${u.username} / ${u.password}`).join(' · ');
+
+            $('start').onclick = () => startLogin().catch(e => setStatus($('login-status'), e.message, false));
+            $('reset').onclick = () => { clear(); window.location.href = '/'; };
+            $('call-me').onclick = () => callApi(cfg.protected_endpoint, true);
+            $('call-me-anon').onclick = () => callApi(cfg.protected_endpoint, false);
+            $('call-userinfo').onclick = () => callApi(cfg.userinfo_endpoint, true);
+            $('refresh').onclick = () => refreshToken().catch(e => setStatus($('api-status'), e.message, false));
+            $('list-grants').onclick = () => callApi('/api/v1/oauth2/grants', true);
+            $('revoke-grant').onclick = async () => {
+                const { token } = load();
+                const res = await fetch(`/api/v1/oauth2/grants/${cfg.client_id}`, {
+                    method: 'DELETE',
+                    headers: { Authorization: `${token.token_type} ${token.access_token}` },
+                    credentials: 'omit',
+                });
+                setStatus($('api-status'), `${res.status} ${res.statusText}`, res.ok);
+                show(await res.text() || '(grant revoked — the next login asks for consent again)');
+            };
+
+            const qs = new URLSearchParams(window.location.search);
+            if (qs.get('error')) {
+                setStatus($('login-status'), `authorization denied: ${qs.get('error')}`, false);
+                history.replaceState({}, '', '/');
+                return;
+            }
+            if (qs.get('code')) {
+                setStatus($('login-status'), 'exchanging the authorization code…');
+                try {
+                    const token = await exchangeCode(qs.get('code'), qs.get('state'));
+                    history.replaceState({}, '', '/');
+                    setStatus($('login-status'), 'logged in — access token issued', true);
+                    renderToken(token);
+                } catch (err) {
+                    history.replaceState({}, '', '/');
+                    setStatus($('login-status'), err.message, false);
+                }
+                return;
+            }
+            const { token } = load();
+            if (token) {
+                setStatus($('login-status'), 'token restored from sessionStorage', true);
+                renderToken(token);
+            }
+        })();
+    </script>
+</body>
+
+</html>

--- a/examples/static/oauth2_index.html
+++ b/examples/static/oauth2_index.html
@@ -43,10 +43,15 @@
         <h2>Authorization Code Flow</h2>
         <p>1. Start the flow by clicking the button below. You will be redirected to Login, then Consent, then back to
             the Callback URL with a code.</p>
-        <p><strong>Client ID:</strong> <code>1</code></p>
+        <p><strong>Client ID:</strong> <code>nav_public_client</code> (public — PKCE S256 required)</p>
         <p><strong>Redirect URI:</strong> <code>http://localhost:5000/static/callback.html</code></p>
+        <p>
+            This page starts the flow <em>without</em> PKCE, so the exchange will be rejected with
+            <code>invalid_grant: PKCE required for public clients</code>. That is the correct behaviour for a
+            public client — see <code>examples/oauth2_3lo_server.py</code> for the complete flow with PKCE.
+        </p>
         <a
-            href="/oauth2/authorize?client_id=1&redirect_uri=http://localhost:5000/static/callback.html&response_type=code&state=xyz123&scope=user:read"><button>Authorize</button></a>
+            href="/oauth2/authorize?client_id=nav_public_client&redirect_uri=http://localhost:5000/static/callback.html&response_type=code&state=xyz123&scope=default+profile"><button>Authorize</button></a>
     </div>
 
     <div class="section">
@@ -54,12 +59,13 @@
         <p>Use curl to test:</p>
         <pre><code>curl -X POST http://localhost:5000/oauth2/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=1&client_secret=test_client_secret"</code></pre>
+  -d "grant_type=client_credentials&client_id=nav_confidential_client&client_secret=confidential_s3cr3t"</code></pre>
     </div>
 
     <div class="section">
         <h2>Setup</h2>
-        <p>Ensure you have created the 'test_client_id' in the backend storage (Memory/Redis/DB).</p>
+        <p>The clients above are registered on startup by <code>examples/oauth2_server.py</code> in the
+            in-memory client storage (<code>OAUTH2_CLIENT_STORAGE=memory</code>).</p>
     </div>
 </body>
 

--- a/navigator_auth/auth.py
+++ b/navigator_auth/auth.py
@@ -77,11 +77,31 @@ class AuthHandler:
     app: web.Application = None
     secure_cookies: bool = True
 
-    def __init__(self, app_name: str = "auth", secure_cookies: bool = True, **kwargs) -> None:
+    def __init__(
+        self,
+        app_name: str = "auth",
+        secure_cookies: bool = True,
+        enable_authdb: bool = True,
+        **kwargs,
+    ) -> None:
+        """AuthHandler.
+
+        Args:
+            app_name: key under which this handler is registered on the app.
+            secure_cookies: enable secure session cookies.
+            enable_authdb: when False, the PostgreSQL ``authdb`` pool is not
+                configured on the application. Useful for deployments (and for
+                the bundled examples) that only use storage-less backends
+                — in-memory / Redis OAuth2 client storage plus a custom
+                IdentityProvider — and therefore have no auth database.
+                Backends that do need ``app["authdb"]`` will fail at request
+                time, exactly as they do today when the pool is missing.
+        """
         self.name: str = app_name
         self.backends: dict = {}
         self._session = None
         self.secure_cookies = secure_cookies
+        self.enable_authdb = enable_authdb
         if "scheme" in kwargs:
             self.auth_scheme = kwargs["scheme"]
         else:
@@ -579,13 +599,18 @@ class AuthHandler:
                 reason=f"Error creating Redis connection: {ex}"
             ) from ex
         ## getting Database Connection:
-        try:
-            pool = PostgresStorage(driver="pg", dsn=default_dsn)
-            pool.configure(self.app)  # pylint: disable=E1123
-        except RuntimeError as ex:
-            raise web.HTTPServerError(
-                reason=f"Error creating Database connection: {ex}"
-            ) from ex
+        if self.enable_authdb:
+            try:
+                pool = PostgresStorage(driver="pg", dsn=default_dsn)
+                pool.configure(self.app)  # pylint: disable=E1123
+            except RuntimeError as ex:
+                raise web.HTTPServerError(
+                    reason=f"Error creating Database connection: {ex}"
+                ) from ex
+        else:
+            logging.warning(
+                "Auth: 'authdb' PostgreSQL pool disabled (enable_authdb=False)."
+            )
         # startup operations over extension backend
         self.app.on_startup.append(self.auth_startup)
         # cleanup operations over Auth backend
@@ -885,6 +910,31 @@ class AuthHandler:
             return True
         return False  # Assuming no authentication match by default
 
+    async def _token_is_revoked(self, payload: dict) -> bool:
+        """Return True when this token's ``jti`` was revoked (RFC 7009).
+
+        OAuth2 access tokens are self-contained JWTs, so revoking one only
+        marks its ``jti`` in the provider's access-token storage. Without this
+        check a revoked token would keep passing ``auth_middleware`` until it
+        expires. Only tokens that actually carry a ``jti`` (i.e. OAuth2 ones)
+        cost a storage lookup.
+        """
+        jti = payload.get("jti") if payload else None
+        if not jti:
+            return False
+        for backend in self.backends.values():
+            storage = getattr(backend, "access_token_storage", None)
+            if storage is None:
+                continue
+            try:
+                if await storage.is_revoked(jti):
+                    return True
+            except Exception as exc:  # pylint: disable=W0703
+                self.logger.warning(
+                    f"Auth Middleware: unable to check revocation of jti={jti}: {exc}"
+                )
+        return False
+
     @web.middleware
     async def auth_middleware(
         self,
@@ -902,7 +952,7 @@ class AuthHandler:
                 try:
                     token = await self._idp.get_payload(request)
                     _, payload = self._idp.decode_token(code=token)
-                    if payload:
+                    if payload and not await self._token_is_revoked(payload):
                         session = await get_session(request, payload, new=False)
                         if session:
                             user = await self.get_session_user(session)
@@ -922,6 +972,14 @@ class AuthHandler:
         except AuthExpired as err:
             self.logger.error(f"Auth Middleware: Credentials expired: {err}")
             raise self.Unauthorized(reason=err.message, exception=err) from err
+        except AuthException as err:
+            # Malformed / unsigned / undecodable token: this is a rejected
+            # credential (401), not a server error (it used to escape here and
+            # surface as a 500).
+            self.logger.error(f"Auth Middleware: Invalid credentials: {err}")
+            raise self.Unauthorized(reason=err.message, exception=err) from err
+        if payload and await self._token_is_revoked(payload):
+            raise self.Unauthorized(reason="Token has been revoked")
         try:
             if payload:
                 ## check if user has a session:
@@ -1010,7 +1068,13 @@ class AuthHandler:
                     except Exception as ex:  # pylint: disable=W0703
                         self.logger.error(f"Missing User Object from Session: {ex}")
             elif self.secure_cookies is True:
-                session = await get_session(request, None, new=False)
+                # No bearer token: fall back to the session cookie. This branch
+                # exists precisely for cookie-based sessions (the browser leg of
+                # the OAuth2 flow, e.g. /oauth2/consent), so the cookie must be
+                # honoured -- get_session() ignores it by default.
+                session = await get_session(
+                    request, None, new=False, ignore_cookie=False
+                )
                 if not session:
                     raise self.Unauthorized(
                         reason="There is no Session or Authentication is missing"

--- a/navigator_auth/backends/idp/__init__.py
+++ b/navigator_auth/backends/idp/__init__.py
@@ -1,4 +1,5 @@
 import time
+from typing import Union
 from datetime import datetime, timedelta, timezone
 import hashlib
 import base64
@@ -314,13 +315,38 @@ class IdentityProvider:
         refresh_token = self.create_refresh_token()
         return jwt_token, refresh_token, exp, self.scheme
 
-    def decode_token(self, code: str, issuer: str = None):
+    def decode_token(
+        self,
+        code: str,
+        issuer: str = None,
+        audience: Union[str, list[str], None] = None,
+    ):
+        """Decode a Navigator JWT.
+
+        Args:
+            code: the raw token (optionally prefixed with ``<tenant>:``).
+            issuer: expected ``iss`` claim. When omitted, the issuer is *not*
+                verified (this used to be passed to PyJWT as an unsupported
+                ``iss=`` kwarg, which PyJWT silently ignored — and warns about
+                since 2.10, fatally under ``-W error``).
+            audience: expected ``aud`` claim. When omitted, the ``aud`` claim
+                is *not* verified.
+
+        Note:
+            ``create_token(audience=...)`` mints tokens carrying an ``aud``
+            claim (FEAT-093 TASK-029 uses ``'user'`` for 3LO access tokens and
+            ``'app'`` for client-credentials tokens). PyJWT rejects any token
+            with an ``aud`` claim when ``decode()`` is called without an
+            ``audience`` argument, which made every OAuth2 access token
+            undecodable by the auth middleware, ``/oauth2/userinfo``,
+            ``/oauth2/revoke`` and ``/oauth2/introspect``. Audience is a
+            token-class marker here, not a resource identifier, so validation
+            is opt-in: callers that care pass ``audience`` explicitly.
+        """
         payload = None
         tenant = None
         if not code:
             return [None, None]
-        if not issuer:
-            issuer = AUTH_TOKEN_ISSUER
         try:
             tenant, jwt_token = code.split(":")
         except (TypeError, ValueError, AttributeError):
@@ -333,7 +359,12 @@ class IdentityProvider:
                 jwt_token,
                 SECRET_KEY,
                 algorithms=[AUTH_JWT_ALGORITHM],
-                iss=issuer,
+                issuer=issuer,
+                audience=audience,
+                options={
+                    "verify_aud": audience is not None,
+                    "verify_iss": issuer is not None,
+                },
                 leeway=30,
             )
             self.logger.debug(f"Decoded Token: {payload!s}")

--- a/navigator_auth/backends/oauth2/backend.py
+++ b/navigator_auth/backends/oauth2/backend.py
@@ -66,7 +66,15 @@ from ...conf import (
     OAUTH_DEVICE_MAX_USER_CODE_ATTEMPTS,
     OAUTH_DEVICE_LOCKOUT_TTL,
 )
-from navigator_session import get_session
+from navigator_session import (
+    get_session,
+    SESSION_ID,
+)
+from navigator_session.conf import (
+    SESSION_OBJECT,
+    SESSION_REQUEST_KEY,
+    SESSION_STORAGE,
+)
 from ...exceptions import (
     FailedAuth,
     UserNotFound,
@@ -346,6 +354,110 @@ class Oauth2Provider(BaseAuthBackend):
             self.logger.warning(f"Could not decode session user: {e}")
         return None
 
+    # ------------------------------------------------------------------
+    # Session binding
+    # ------------------------------------------------------------------
+    #
+    # navigator-auth resolves the current user from a *server-side session*:
+    # ``AuthHandler.auth_middleware`` decodes the bearer JWT and then loads the
+    # session it points at, and ``@user_session()`` reads the user out of that
+    # session. An OAuth2 access token therefore has to be bound to a session,
+    # exactly like the token BasicAuth mints in ``remember()``; otherwise every
+    # request carrying a perfectly valid 3LO token is rejected because no
+    # session can be resolved from its claims.
+
+    def _session_storage(self, request: web.Request):
+        """Return the configured session storage (or None when unavailable)."""
+        storage = request.get(SESSION_STORAGE)
+        if storage is not None:
+            return storage
+        try:
+            return request.app["auth"].session.storage
+        except (KeyError, AttributeError, TypeError):
+            return None
+
+    async def _create_user_session(
+        self,
+        request: web.Request,
+        user: Any,
+        response: web.StreamResponse = None,
+    ):
+        """Create (or refresh) the server-side session for a resource owner.
+
+        The session is keyed by the user's identity, so the interactive login
+        and any token minted for that same user share one session — the same
+        one-session-per-user model the other backends use.
+
+        Args:
+            request: the current request.
+            user: the authenticated user object.
+            response: when given, the session cookie is written on it (needed
+                for the browser leg: ``/oauth2/login`` -> ``/oauth2/authorize``).
+
+        Returns:
+            The ``SessionData`` object, or None when no storage is configured.
+        """
+        storage = self._session_storage(request)
+        if storage is None:
+            self.logger.error("Oauth2: no session storage configured.")
+            return None
+        try:
+            identity = user[self.username_attribute]
+        except (KeyError, TypeError):
+            identity = getattr(user, self.username_attribute, None)
+        if not identity:
+            self.logger.error("Oauth2: cannot resolve the user identity for a session.")
+            return None
+        identity = str(identity)
+        try:
+            user.is_authenticated = True
+        except (AttributeError, TypeError):
+            pass
+        # Resolve the session purely from the identity: a stale session id left
+        # on the request (e.g. a cookie from another user) must not be reused.
+        for key in (SESSION_ID, SESSION_OBJECT, SESSION_REQUEST_KEY):
+            request.pop(key, None)
+        request[self.session_key_property] = identity
+        session_data = {
+            self.session_key_property: identity,
+            "user": jsonpickle.encode(user),
+        }
+        try:
+            session = await storage.new_session(request, session_data, response=response)
+        except TypeError:
+            # storages whose new_session() has no ``response`` argument.
+            session = await storage.new_session(request, session_data)
+        if not session:
+            self.logger.error("Oauth2: unable to create the User session.")
+            return None
+        return session
+
+    async def _token_session_claims(self, request: web.Request, user_id: int) -> dict:
+        """Bind a freshly issued access token to a session.
+
+        Returns the extra JWT claims (``id``, ``session_id``, ``username``)
+        that let ``auth_middleware`` resolve the session — and therefore the
+        user — from the bearer token alone. Returns an empty dict when the
+        resource owner cannot be resolved, leaving the token usable for
+        introspection-based resource servers.
+        """
+        try:
+            user = await self._idp.user_from_id(user_id)
+        except Exception as exc:  # pylint: disable=W0703
+            self.logger.warning(
+                f"Oauth2: cannot bind a session to the token for user_id={user_id}: {exc}"
+            )
+            return {}
+        session = await self._create_user_session(request, user)
+        if not session:
+            return {}
+        identity = str(user[self.username_attribute])
+        return {
+            self.session_key_property: identity,
+            self.session_id_property: session.session_id,
+            self.username_attribute: identity,
+        }
+
     async def validate_client(self, client_id, redirect_uri=None, request=None):
         """Fetch client by public uid; optionally validate redirect_uri (exact match)."""
         client = await self.client_storage.get_client(client_id, request=request)
@@ -585,34 +697,49 @@ class Oauth2Provider(BaseAuthBackend):
             except Exception as exc:
                 raise web.HTTPBadRequest(reason=f"Auth: Exception {exc}")
 
-            redirect_uri = data.get("redirect_uri")
-            client_id = data.get("client_id")
-            state = data.get("state")
-            scope = data.get("scope")
-
             location = request.app.router["nav_oauth2_authorize"].url_for()
             payload = {
-                "client_id": client_id,
-                "redirect_uri": redirect_uri,
-                "state": state,
-                "scope": scope,
-                "response_type": "code",
+                "client_id": data.get("client_id"),
+                "redirect_uri": data.get("redirect_uri"),
+                "response_type": data.get("response_type", "code") or "code",
             }
+            # Carry the rest of the authorization request across the login hop.
+            # PKCE in particular MUST survive it: dropping code_challenge here
+            # makes every public-client exchange fail later with
+            # "PKCE required for public clients".
+            for key in (
+                "state",
+                "scope",
+                "code_challenge",
+                "code_challenge_method",
+                "nonce",
+                "prompt",
+            ):
+                value = data.get(key)
+                if value:
+                    payload[key] = value
+            payload = {k: v for k, v in payload.items() if v is not None}
             url = location.with_query(**payload)
             response = web.HTTPFound(url)
 
+            # Establish the browser session for the resource owner: the
+            # session cookie is written on this redirect, and /oauth2/authorize
+            # reads it back on the next hop (see check_session).
             try:
-                auth_handler = request.app.get("auth")
-                if auth_handler:
-                    encoded_user = jsonpickle.encode(user)
-                    session_data = {"user": encoded_user}
-                    session = await auth_handler.session.storage.load_session(
-                        request, session_data, response=response, new=True
+                session = await self._create_user_session(
+                    request, user, response=response
+                )
+                if not session:
+                    raise web.HTTPBadRequest(
+                        reason="Auth: unable to create the User session."
                     )
-                    if session:
-                        session["user"] = encoded_user
-            except Exception as e:
+            except web.HTTPException:
+                raise
+            except Exception as e:  # pylint: disable=W0703
                 self.logger.error(f"Error creating session: {e}")
+                raise web.HTTPBadRequest(
+                    reason=f"Auth: unable to create the User session: {e}"
+                ) from e
 
             return response
         else:
@@ -733,6 +860,9 @@ class Oauth2Provider(BaseAuthBackend):
             "client_id": client.client_id,   # public uid in JWT claim
             "scope": scope,
             "jti": jti,
+            # Bind the token to a session so the auth middleware,
+            # @is_authenticated() and @user_session() can resolve the user.
+            **await self._token_session_claims(request, user_id),
         }
 
         # TASK-029: audience = 'user' for 3LO tokens.
@@ -905,6 +1035,8 @@ class Oauth2Provider(BaseAuthBackend):
             "client_id": client.client_id,
             "scope": scope,
             "jti": jti,
+            # Same session binding as the authorization_code grant.
+            **await self._token_session_claims(request, user_id),
         }
 
         # TASK-029: audience = 'user'.
@@ -1684,17 +1816,92 @@ class Oauth2Provider(BaseAuthBackend):
             return web.Response(status=200, text="Authorization approved. You may close this window.")
 
     def _get_request_user_id(self, request) -> Optional[int]:
-        """Extract user_id from the authenticated request."""
-        try:
-            userinfo = request.get("userinfo", {})
-            if isinstance(userinfo, dict):
-                uid = userinfo.get("user_id")
+        """Extract user_id from the authenticated request.
+
+        The auth middleware publishes the decoded token claims under
+        ``request["userdata"]`` (``"userinfo"`` is the ABAC context key, which
+        nothing sets on the request — reading only that made every call to the
+        grants API return 401). The authenticated user object is used as a
+        fallback for cookie-session requests, whose claims are not on the
+        request at all.
+        """
+        for source in (request.get("userdata"), request.get("userinfo")):
+            if isinstance(source, dict):
+                uid = source.get("user_id")
                 if uid:
+                    try:
+                        return int(uid)
+                    except (TypeError, ValueError):
+                        pass
+        user = request.get(self.user_property) or getattr(request, "user", None)
+        for attr in (self.userid_attribute, "user_id", "id"):
+            uid = getattr(user, attr, None) if user is not None else None
+            if uid:
+                try:
                     return int(uid)
-        except Exception:
-            pass
+                except (TypeError, ValueError):
+                    continue
         return None
 
+    # ------------------------------------------------------------------
+    # Resource-Server side: validating an issued access token
+    # ------------------------------------------------------------------
+
+    async def authenticate(self, request: web.Request):
+        """Validate the ``Authorization: Bearer <access_token>`` credential.
+
+        This is the Resource-Server half of the provider and the hook
+        ``@is_authenticated()`` calls when a request has not already been
+        authenticated by ``AuthHandler.auth_middleware``. On success the
+        user, the session and the token claims are attached to the request.
+
+        Returns:
+            The decoded token claims.
+
+        Raises:
+            InvalidAuth: no token, invalid/expired token, revoked ``jti``, or
+                a token that resolves to no session/user.
+        """
+        token = await self._idp.get_payload(request)
+        if not token:
+            raise InvalidAuth("Oauth2: Missing Bearer access token.", status=401)
+        _, payload = self._idp.decode_token(code=token)
+        if not payload:
+            raise InvalidAuth("Oauth2: Invalid access token.", status=401)
+
+        # Real-time revocation check (RFC 7009 marks the jti, not the JWT).
+        jti = payload.get("jti")
+        if jti and self.access_token_storage:
+            try:
+                if await self.access_token_storage.is_revoked(jti):
+                    raise InvalidAuth(
+                        "Oauth2: access token has been revoked.", status=401
+                    )
+            except InvalidAuth:
+                raise
+            except Exception as exc:  # pylint: disable=W0703
+                self.logger.warning(f"Oauth2: cannot check jti revocation: {exc}")
+
+        try:
+            session = await get_session(request, payload, new=False)
+        except Exception as exc:  # pylint: disable=W0703
+            self.logger.error(f"Oauth2: error loading the token session: {exc}")
+            session = None
+        if not session:
+            raise InvalidAuth(
+                "Oauth2: the access token is not bound to a valid session.",
+                status=401,
+            )
+        user = await self.get_session_user(session)
+        if not user:
+            raise InvalidAuth(
+                "Oauth2: cannot resolve the user of this access token.", status=401
+            )
+        request["userdata"] = payload
+        request["authenticated"] = True
+        self._set_user_request(request, user)
+        return payload
+
     async def check_credentials(self, request):
-        """Authentication and create a session."""
-        return True
+        """Check the credentials carried by the request (bearer access token)."""
+        return await self.authenticate(request)

--- a/navigator_auth/conf.py
+++ b/navigator_auth/conf.py
@@ -150,8 +150,15 @@ AUTH_LOGIN_FAILED_URI = config.get("AUTH_LOGIN_FAILED_URI", fallback="/login")
 AUTH_LOGOUT_REDIRECT_URI = config.get("AUTH_LOGOUT_REDIRECT_URI", fallback="/oauth2/logout/complete")
 AUTH_SUCCESSFUL_CALLBACKS = ()
 
-# Enable authentication backends
-AUTHENTICATION_BACKENDS = ()
+# Enable authentication backends.
+# Comma-separated list of dotted paths, e.g.:
+#   AUTHENTICATION_BACKENDS="navigator_auth.backends.BasicAuth,navigator_auth.backends.oauth2.Oauth2Provider"
+# Defaults to an empty tuple (no backend enabled) to preserve previous behaviour.
+AUTHENTICATION_BACKENDS = tuple(
+    e.strip()
+    for e in config.get("AUTHENTICATION_BACKENDS", fallback="").split(",")
+    if e.strip()
+)
 
 # No permissive fallback: if AUTHORIZATION_BACKENDS is unset/empty, no authz
 # backend is active (requests must pass authentication, not a host allowlist).

--- a/templates/oauth/consent.html
+++ b/templates/oauth/consent.html
@@ -34,7 +34,13 @@
             <input type="hidden" name="state" value="{{ state }}">
             <input type="hidden" name="scope" value="{{ scope }}">
             <input type="hidden" name="response_type" value="{{ response_type }}">
-            
+            <!-- PKCE: the challenge captured at /oauth2/authorize has to reach
+                 _issue_code(), otherwise the code is minted without it and the
+                 token exchange rejects the public client. -->
+            <input type="hidden" name="code_challenge" value="{{ code_challenge }}">
+            <input type="hidden" name="code_challenge_method" value="{{ code_challenge_method }}">
+            <input type="hidden" name="nonce" value="{{ nonce }}">
+
             <div class="actions">
                 <button type="submit" name="action" value="deny" class="btn-deny">Deny</button>
                 <button type="submit" name="action" value="approve" class="btn-approve">Approve</button>

--- a/templates/oauth/login.html
+++ b/templates/oauth/login.html
@@ -31,6 +31,10 @@
         <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}">
         <input type="hidden" name="scope" value="{{ scope }}">
         <input type="hidden" name="state" value="{{ state }}">
+        <input type="hidden" name="code_challenge" value="{{ code_challenge }}">
+        <input type="hidden" name="code_challenge_method" value="{{ code_challenge_method }}">
+        <input type="hidden" name="nonce" value="{{ nonce }}">
+        <input type="hidden" name="prompt" value="{{ prompt }}">
         <input type="submit" value="Submit">
     </form>
   </div>

--- a/tests/test_oauth2_3lo_session_binding.py
+++ b/tests/test_oauth2_3lo_session_binding.py
@@ -1,0 +1,168 @@
+"""Regression tests for the 3LO end-to-end path (see examples/oauth2_3lo_server.py).
+
+The Authorization-Code + PKCE flow only becomes usable when the *issued* access
+token can actually authenticate a request. These tests lock down the four
+defects that broke that path:
+
+1. ``IdentityProvider.decode_token`` rejected every token carrying an ``aud``
+   claim — which is every 3LO access token, since ``create_token`` is called
+   with ``audience="user"``.
+2. ``Oauth2Provider`` minted access tokens with no session linkage, so
+   ``auth_middleware`` / ``@user_session()`` could not resolve a user from them.
+3. The login and consent templates dropped ``code_challenge``, so PKCE never
+   survived the interactive hops and public clients failed the exchange.
+4. ``_get_request_user_id`` read ``request["userinfo"]``, a key nothing sets,
+   making the grants API answer 401 to authenticated users.
+"""
+
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from navigator_auth.backends.idp import IdentityProvider
+from navigator_auth.backends.oauth2.backend import Oauth2Provider
+
+
+TEMPLATES = Path(__file__).resolve().parent.parent / "templates" / "oauth"
+
+
+# ---------------------------------------------------------------------------
+# 1. decode_token and the `aud` claim
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def idp():
+    return IdentityProvider()
+
+
+class TestDecodeTokenAudience:
+    def test_token_with_audience_is_decodable(self, idp):
+        """A 3LO access token (aud='user') must decode by default."""
+        token, _, _, _ = idp.create_token(
+            {"user_id": 7, "client_id": "app", "scope": "default"},
+            expiration=300,
+            audience="user",
+        )
+        _, payload = idp.decode_token(token)
+        assert payload["user_id"] == 7
+        assert payload["aud"] == "user"
+
+    def test_token_without_audience_still_decodable(self, idp):
+        token, _, _, _ = idp.create_token({"user_id": 7}, expiration=300)
+        _, payload = idp.decode_token(token)
+        assert payload["user_id"] == 7
+        assert "aud" not in payload
+
+    def test_audience_is_verified_when_requested(self, idp):
+        """Opt-in verification still rejects a token minted for another audience."""
+        token, _, _, _ = idp.create_token(
+            {"user_id": 7}, expiration=300, audience="app"
+        )
+        assert idp.decode_token(token, audience="app")[1]["user_id"] == 7
+        with pytest.raises(Exception):
+            idp.decode_token(token, audience="user")
+
+
+# ---------------------------------------------------------------------------
+# 2. Access tokens are bound to a session
+# ---------------------------------------------------------------------------
+
+class DummyUser(dict):
+    """Minimal stand-in for a navigator-auth User row."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.__dict__.update(kwargs)
+        self.is_authenticated = False
+
+
+@pytest.fixture
+def provider():
+    prov = Oauth2Provider(user_model=MagicMock(), identity=MagicMock())
+    prov.logger = MagicMock()
+    return prov
+
+
+def make_request(storage):
+    """A request-like mapping carrying an app with an AuthHandler session."""
+    auth = MagicMock()
+    auth.session.storage = storage
+    request = MagicMock()
+    store = {}
+    request.get = lambda key, default=None: store.get(key, default)
+    request.pop = lambda key, default=None: store.pop(key, default)
+    request.__setitem__ = lambda self_, key, value: store.__setitem__(key, value)
+    request.app = {"auth": auth}
+    request.store = store
+    return request
+
+
+class TestTokenSessionBinding:
+    @pytest.mark.asyncio
+    async def test_claims_carry_session_and_identity(self, provider):
+        session = MagicMock()
+        session.session_id = "sess-abc"
+        storage = MagicMock()
+        storage.new_session = AsyncMock(return_value=session)
+
+        provider._idp.user_from_id = AsyncMock(
+            return_value=DummyUser(user_id=11, username="demo")
+        )
+        request = make_request(storage)
+
+        claims = await provider._token_session_claims(request, 11)
+
+        assert claims == {
+            provider.session_key_property: "demo",
+            provider.session_id_property: "sess-abc",
+            provider.username_attribute: "demo",
+        }
+        # The session must actually hold the encoded user for @user_session().
+        _, session_data = storage.new_session.call_args[0]
+        assert "user" in session_data
+        assert session_data[provider.session_key_property] == "demo"
+
+    @pytest.mark.asyncio
+    async def test_unknown_user_degrades_without_raising(self, provider):
+        provider._idp.user_from_id = AsyncMock(side_effect=RuntimeError("no such user"))
+        request = make_request(MagicMock())
+        assert await provider._token_session_claims(request, 404) == {}
+
+
+# ---------------------------------------------------------------------------
+# 3. PKCE survives the interactive hops
+# ---------------------------------------------------------------------------
+
+class TestPkcePropagation:
+    @pytest.mark.parametrize("template", ["login.html", "consent.html"])
+    def test_template_forwards_the_code_challenge(self, template):
+        body = (TEMPLATES / template).read_text()
+        for field in ("code_challenge", "code_challenge_method"):
+            assert re.search(
+                rf'name="{field}"\s+value="{{{{\s*{field}\s*}}}}"', body
+            ), f"{template} does not forward {field}"
+
+
+# ---------------------------------------------------------------------------
+# 4. The grants API can identify the caller
+# ---------------------------------------------------------------------------
+
+class TestRequestUserId:
+    def test_reads_the_token_claims(self, provider):
+        request = MagicMock()
+        request.get = {"userdata": {"user_id": "31"}}.get
+        assert provider._get_request_user_id(request) == 31
+
+    def test_falls_back_to_the_session_user(self, provider):
+        request = MagicMock()
+        request.get = {}.get
+        request.user = DummyUser(user_id=5, username="demo")
+        assert provider._get_request_user_id(request) == 5
+
+    def test_returns_none_when_anonymous(self, provider):
+        request = MagicMock()
+        request.get = {}.get
+        request.user = None
+        assert provider._get_request_user_id(request) is None


### PR DESCRIPTION
## Summary

This PR adds a complete, runnable end-to-end OAuth2 Authorization Code + PKCE (3LO) example and fixes critical defects that prevented issued access tokens from authenticating requests.

## Key Changes

### New Example Application
- **`examples/oauth2_3lo_server.py`** — A self-contained aiohttp server that demonstrates the full 3LO flow in one browser tab:
  - Acts as Authorization Server, Client Application (SPA), and Resource Server simultaneously
  - Uses in-memory OAuth2 client storage and a demo identity provider (no PostgreSQL required)
  - Includes a protected endpoint (`GET /api/v1/me`) decorated with `@is_authenticated()` and `@user_session()`
  - Demonstrates PKCE, consent flow, token exchange, and token refresh with rotation

- **`examples/static/oauth2_3lo_app.html`** — Interactive single-page application that walks through the flow:
  - Generates PKCE code_verifier/code_challenge pair
  - Initiates OAuth2 authorization and handles the callback
  - Exchanges authorization code for access token
  - Calls protected resource with bearer token
  - Exercises token refresh, userinfo endpoint, and consent grants API

- **`examples/README.md`** — Documentation explaining the example, how to run it, and what it demonstrates

### Core Fixes to OAuth2 Backend

1. **Session Binding for Access Tokens** (`navigator_auth/backends/oauth2/backend.py`):
   - Added `_create_user_session()` — creates/refreshes server-side session for resource owner
   - Added `_token_session_claims()` — binds issued access tokens to sessions by including `session_id` and user identity in JWT claims
   - Modified `_handle_authorization_code()` and `_handle_refresh_token()` to call `_token_session_claims()`, ensuring tokens can be resolved by `auth_middleware` and `@user_session()`
   - Updated `auth_login()` to properly establish browser session during interactive login flow

2. **Token Audience Handling** (`navigator_auth/backends/idp/__init__.py`):
   - Modified `decode_token()` to accept optional `audience` parameter
   - Tokens with `aud` claim now decode successfully by default (audience verification is opt-in)
   - Fixes rejection of 3LO access tokens which carry `aud='user'` claim

3. **PKCE Propagation** (`templates/oauth/login.html`, `templates/oauth/consent.html`):
   - Added hidden form fields to forward `code_challenge` and `code_challenge_method` through interactive login/consent hops
   - Ensures PKCE parameters survive the browser redirects and reach the token endpoint

4. **Request User ID Resolution** (`navigator_auth/backends/oauth2/backend.py`):
   - Fixed `_get_request_user_id()` to read from `request["userdata"]` (token claims) instead of non-existent `request["userinfo"]`
   - Enables grants API to identify authenticated callers

### Infrastructure Changes

- **`AuthHandler.__init__()`** — Added `enable_authdb` parameter to optionally disable PostgreSQL pool configuration
  - Allows deployments using only storage-less backends to skip database setup
  - Used by the example to avoid PostgreSQL dependency

- **`AuthHandler.setup()`** — Conditionally configures authdb pool based on `enable_authdb` flag

- **`AuthHandler._token_is_revoked()`** — New method to check if a token's `jti` was revoked (RFC 7009)
  - Called by `auth_middleware` to reject revoked access tokens

### Documentation Updates

- Updated `examples/oauth2_server.py` docstring to reference the new 3LO example
- Updated `examples/static/oauth2_index.html` to clarify client IDs and PKCE requirements
- Updated `navigator_auth/conf.py` documentation for `AUTHENTICATION_BACKENDS`

## Implementation Details

The core insight: navigator-auth resolves users from **server-side sessions**, not JWTs alone. When OAuth

https://claude.ai/code/session_01TT7zwrH26WwYzQnckbXKab