### PR TITLE
security(redirect): validate user-supplied redirect targets against AUTH_TRUSTED_DOMAINS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Unreleased
 
+- **Open-redirect protection — `AUTH_TRUSTED_DOMAINS`.** Every
+  frontend-supplied redirect target (`?redirect_uri=` on login routes, SAML
+  `RelayState`, Azure/ADFS `internal_redirect`, the identity-link
+  `finish_redirect`) now goes through a single gate,
+  `navigator_auth.libs.redirect.safe_redirect_url`, before a `302` is
+  issued. Relative paths are resolved on the current domain; absolute
+  `http(s)` targets are honoured only when their *hostname* is one of
+  `AUTH_TRUSTED_DOMAINS` (or a sub-domain of one, or the host serving the
+  request); mobile deep-link schemes are accepted (optionally restricted by
+  `AUTH_TRUSTED_REDIRECT_SCHEMES`), browser-executable schemes never are.
+  Protocol-relative (`//evil.com`), backslash and `user@host` netloc tricks
+  that bypassed the previous per-backend checks are rejected; a rejected
+  target logs a warning and falls back to `AUTH_REDIRECT_URI` instead of
+  breaking the login. Defaults to `localhost` plus `DOMAIN`/`DOMAIN_HOST`,
+  so single-domain deployments need no change; multi-app deployments should
+  set `AUTH_TRUSTED_DOMAINS` explicitly. `BaseAuthBackend.validate_redirect_host` (ADFS relay, SAML
+  RelayState / `redirect_uri`) now delegates to the same gate instead of
+  glob-matching the raw netloc against `ALLOWED_HOSTS`. See `documentation/trusted-redirects.md`.
 - **Abstract SAML 2.0 Backend — SP and IdP roles on `pysaml2` (0.26.0).**
   **Breaking:** `python3-saml`/`xmlsec` are replaced by `pysaml2>=7.5,<8`;
   the `xmlsec1` system binary is now required (was: the `xmlsec`

--- a/documentation/trusted-redirects.md
+++ b/documentation/trusted-redirects.md
@@ -1,0 +1,66 @@
+# Trusted Redirect Domains (open-redirect protection)
+
+Navigator Auth lets the **frontend** decide where the browser lands once
+authentication finishes: `?redirect_uri=` on the login/authorize routes,
+`RelayState` on SAML, `?redirect_uri=` on the identity-link endpoint. One
+backend (for example `api.trocdigital.io`) serves dozens of sub-apps on many
+sub-domains, so that target cannot be a fixed setting.
+
+Honouring it verbatim, however, is a classic **open redirect**: a link such as
+`https://api.example.com/auth/login?redirect_uri=https://evil.com` would send
+a freshly minted token straight to an attacker's page. Every user-supplied
+redirect target now goes through one gate, `navigator_auth.libs.redirect
+.safe_redirect_url`, before a `302` is issued.
+
+## Rules
+
+| Target                                    | Verdict                                                        |
+|-------------------------------------------|----------------------------------------------------------------|
+| `/dashboard`, `dashboard?x=1`             | **Accepted**, resolved on the current request's own domain     |
+| `//evil.com`, `/\evil.com`                | **Rejected** (protocol-relative and backslash variants)         |
+| `https://app.example.com/home`            | **Accepted** when `example.com` (or `app.example.com`) is trusted |
+| `https://example.com.evil.com/`           | **Rejected** (suffix must be a full label boundary)            |
+| `https://example.com@evil.com/`           | **Rejected** (the real host is `evil.com`; only `hostname` is compared, never the raw `netloc`) |
+| `navigator://cb`, `com.example.app:/cb`   | **Accepted** (mobile deep link), see schemes below             |
+| `javascript:`, `data:`, `file:` ...       | **Always rejected**                                            |
+
+A rejected target is logged at `WARNING` and replaced by `AUTH_REDIRECT_URI`
+on the current domain (or by the caller's own fallback), so a tampered link
+degrades to the default landing page instead of breaking the login.
+
+The host that is serving the current request is always trusted, in addition to
+the configured list.
+
+Backends that need a verdict rather than a resolved URL (ADFS relay, SAML
+`RelayState` / `redirect_uri`) use `BaseAuthBackend.validate_redirect_host`,
+which applies the same rules and lets the caller vouch for extra hosts (for
+example a SAML Service Provider's ACS host).
+
+## Settings
+
+```ini
+[auth]
+# Base domains the browser may be sent to. Every sub-domain of an entry is
+# trusted too. Entries may be written as example.com, *.example.com,
+# https://example.com:8443 or localhost:5000 — they are normalised to the
+# bare host name.
+AUTH_TRUSTED_DOMAINS: trocdigital.io,localhost
+
+# Optional: restrict custom (non-HTTP) redirect schemes to this list.
+# Empty (default) accepts any custom scheme except browser-executable ones,
+# because the set of Android/iOS apps served by the API is open-ended.
+AUTH_TRUSTED_REDIRECT_SCHEMES: navigator,com.example.app
+```
+
+| Setting                         | Default                                 |
+|---------------------------------|-----------------------------------------|
+| `AUTH_TRUSTED_DOMAINS`          | `localhost`, `DOMAIN`, host of `DOMAIN_HOST` |
+| `AUTH_TRUSTED_REDIRECT_SCHEMES` | empty (any non-executable custom scheme) |
+
+Production deployments that serve several applications should set
+`AUTH_TRUSTED_DOMAINS` explicitly; the default only covers the single domain
+the API itself is configured with.
+
+`AUTH_TRUSTED_DOMAINS` is unrelated to `ALLOWED_HOSTS`: the latter decides which
+*origins may call* the API (authorization backend `allow_hosts`, glob
+patterns), the former decides where the API may *send the browser*.

--- a/navigator_auth/backends/abstract.py
+++ b/navigator_auth/backends/abstract.py
@@ -29,10 +29,10 @@ from ..conf import (
     AUTH_EXCLUDE_LIST_KEY,
     PREFERRED_AUTH_SCHEME,
     AUTH_REDIRECT_URI,
-    ALLOWED_HOSTS,
 )
 from ..libs.json import json_encoder
 from ..libs.sanitize import sanitize_request
+from ..libs.redirect import safe_redirect_url, is_safe_redirect
 
 # Authenticated Identity
 from ..identities import Identity, AuthBackend
@@ -404,37 +404,45 @@ class BaseAuthBackend(ABC):
         return domain_url
 
     def get_finish_redirect_url(self, request: web.Request) -> str:
+        """Resolve where to send the browser once authentication finishes.
+
+        ``?redirect_uri=`` is frontend-supplied and therefore untrusted: it
+        is passed through :func:`safe_redirect_url`, which only honours
+        relative paths, hosts under ``AUTH_TRUSTED_DOMAINS`` and mobile
+        deep-link schemes, falling back to ``AUTH_REDIRECT_URI`` otherwise.
+        """
         domain_url = self.get_domain(request)
         try:
             redirect_url = request.query["redirect_uri"]
         except (TypeError, KeyError):
             redirect_url = AUTH_REDIRECT_URI
-        if not bool(urlparse(redirect_url).netloc):
-            redirect_url = f"{domain_url}{redirect_url}"
-        self.finish_redirect_url = redirect_url
+        self.finish_redirect_url = safe_redirect_url(
+            request, redirect_url, fallback=AUTH_REDIRECT_URI, domain_url=domain_url
+        )
+        return self.finish_redirect_url
 
     def validate_redirect_host(
-        self, uri: Optional[str], extra_hosts: Iterable[str] = ()
+        self,
+        uri: Optional[str],
+        extra_hosts: Iterable[str] = (),
+        request: Optional[web.Request] = None,
     ) -> Optional[str]:
-        """Only honor an absolute redirect URI whose host is on
-        ALLOWED_HOSTS (or ``extra_hosts``); otherwise drop it and let the
-        caller fall back to a safe default. Relative URIs are always safe.
+        """Return ``uri`` when it is a safe redirect target, else ``None``.
 
-        Promoted from ``ADFSAuth._validate_internal_redirect``
-        (behavior-preserving); shared by every backend that needs to
-        validate a caller-supplied redirect target (ADFS relay, SAML
-        RelayState / redirect_uri).
+        Thin wrapper over :func:`navigator_auth.libs.redirect.is_safe_redirect`
+        for callers that need a *verdict* rather than a resolved URL (ADFS
+        relay, SAML RelayState / ``redirect_uri``): relative paths and mobile
+        deep links are accepted; absolute ``http(s)`` targets only when their
+        hostname is under ``AUTH_TRUSTED_DOMAINS``, the host serving
+        ``request``, or ``extra_hosts`` the caller vouches for (e.g. a SAML
+        SP's ACS host). The caller falls back to a safe default on ``None``.
         """
         if not uri:
             return None
-        netloc = urlparse(uri).netloc
-        if not netloc:
+        if is_safe_redirect(uri, request=request, extra_hosts=extra_hosts):
             return uri
-        for pattern in (*ALLOWED_HOSTS, *extra_hosts):
-            if fnmatch.fnmatch(netloc, pattern):
-                return uri
         self.logger.warning(
-            f"{self._service}: rejected redirect to disallowed host: {netloc!r}"
+            f"{self._service}: rejected redirect to untrusted target: {uri!r}"
         )
         return None
 
@@ -468,11 +476,12 @@ class BaseAuthBackend(ABC):
             headers["x-auth-token-type"] = token_type
             params = {"token": token, "type": token_type}
         if uri is not None:
-            if not bool(urlparse(uri).netloc):
-                domain_url = self.get_domain(request)
-                redirect_url = f"{domain_url}{uri}"
-            else:
-                redirect_url = uri
+            redirect_url = safe_redirect_url(
+                request,
+                uri,
+                fallback=self.finish_redirect_url,
+                domain_url=self.get_domain(request),
+            )
         else:
             redirect_url = self.finish_redirect_url
         url = self.prepare_url(redirect_url, params)

--- a/navigator_auth/backends/adfs.py
+++ b/navigator_auth/backends/adfs.py
@@ -113,14 +113,14 @@ class ADFSAuth(ExternalAuth):
         await super(ADFSAuth, self).on_startup(app)
 
     def _validate_internal_redirect(self, uri: str) -> str:
-        """Only honor an absolute ``internal_redirect`` whose host is on
-        ALLOWED_HOSTS; otherwise drop it and fall back to the default
+        """Only honor an absolute ``internal_redirect`` whose host is under
+        AUTH_TRUSTED_DOMAINS; otherwise drop it and fall back to the default
         finish-redirect behavior in ``home_redirect``. Relative URIs are
         always safe (``home_redirect`` prepends the current request's own
         domain to them).
 
-        Delegates to ``BaseAuthBackend.validate_redirect_host`` (promoted,
-        behavior-preserving; FEAT-097 Module 1)."""
+        Delegates to ``BaseAuthBackend.validate_redirect_host``, which
+        checks the target against ``AUTH_TRUSTED_DOMAINS``."""
         return self.validate_redirect_host(uri)
 
     async def authenticate(self, request: web.Request):

--- a/navigator_auth/backends/external.py
+++ b/navigator_auth/backends/external.py
@@ -21,6 +21,7 @@ from navconfig.logging import logging
 from navigator_session import AUTH_SESSION_OBJECT
 from ..identities import AuthUser
 from ..libs.json import json_decoder
+from ..libs.redirect import safe_redirect_url
 from ..exceptions import UserNotFound, AuthException, InvalidAuth
 from ..identity.flow_store import IdentityFlowStore
 from ..identity.types import TokenResponse
@@ -245,15 +246,25 @@ class ExternalAuth(BaseAuthBackend):
         return f"{domain_url}/auth/{self._service_name}/callback/"
 
     def get_finish_redirect_url(self, request: web.Request) -> str:
+        """Resolve where to send the browser once authentication finishes.
+
+        ``?redirect_uri=`` is frontend-supplied and therefore untrusted: it
+        is passed through :func:`safe_redirect_url`, which only honours
+        relative paths, hosts under ``AUTH_TRUSTED_DOMAINS`` and mobile
+        deep-link schemes, falling back to ``AUTH_REDIRECT_URI`` otherwise.
+        """
         domain_url = self.get_domain(request)
+        fallback = AUTH_REDIRECT_URI if AUTH_REDIRECT_URI else "/"
         try:
             redirect_url = request.query["redirect_uri"]
         except (TypeError, KeyError):
-            redirect_url = AUTH_REDIRECT_URI if AUTH_REDIRECT_URI else "/"
-        if not bool(urlparse(redirect_url).netloc):
-            redirect_url = f"{domain_url}{redirect_url}"
+            redirect_url = fallback
+        redirect_url = safe_redirect_url(
+            request, redirect_url, fallback=fallback, domain_url=domain_url
+        )
         self.logger.notice(f"Redirect URL: {redirect_url}")
         self.finish_redirect_url = redirect_url
+        return redirect_url
 
     def redirect(self, uri: str):
         """redirect.
@@ -302,11 +313,14 @@ class ExternalAuth(BaseAuthBackend):
             params = {**params, **_auth}
         if uri:
             self.logger.notice(f"Redirect to: {uri}")
-            if not bool(urlparse(uri).netloc):
-                domain_url = self.get_domain(request)
-                redirect_url = f"{domain_url}{uri}"
-            else:
-                redirect_url = uri
+            # ``uri`` comes from the client (RelayState, internal_redirect,
+            # ?redirect_uri=) and must pass the trusted-domain gate.
+            redirect_url = safe_redirect_url(
+                request,
+                uri,
+                fallback=self.finish_redirect_url,
+                domain_url=self.get_domain(request),
+            )
         elif AUTH_OAUTH2_REDIRECT_URL is not None:
             # TODO: relative URL and calculate based on Domain
             redirect_url = AUTH_OAUTH2_REDIRECT_URL
@@ -633,9 +647,14 @@ class ExternalAuth(BaseAuthBackend):
                 )
         except Exception:  # pylint: disable=W0703
             pass
-        redirect_to = flow.get("finish_redirect") or "/"
-        if not bool(urlparse(redirect_to).netloc):
-            redirect_to = f"{self.get_domain(request)}{redirect_to}"
+        # ``finish_redirect`` was captured from the query string when the
+        # link flow started: untrusted, so it goes through the same gate.
+        redirect_to = safe_redirect_url(
+            request,
+            flow.get("finish_redirect") or "/",
+            fallback="/",
+            domain_url=self.get_domain(request),
+        )
         return web.HTTPFound(redirect_to)
 
     @abstractmethod

--- a/navigator_auth/conf.py
+++ b/navigator_auth/conf.py
@@ -148,6 +148,33 @@ ALLOWED_HOSTS = [
 ## Redirections:
 AUTH_REDIRECT_URI = config.get("AUTH_REDIRECT_URI", fallback="/")
 AUTH_FAILED_REDIRECT_URI = config.get("AUTH_FAILED_REDIRECT_URI", fallback="/login")
+
+# Open-redirect protection for user-supplied redirect targets
+# (``?redirect_uri=``, SAML ``RelayState``, identity-link ``finish_redirect``).
+# Base domains the browser may be sent to after login; every subdomain of an
+# entry is trusted too, and the host serving the current request is always
+# trusted. Defaults to ``localhost`` plus DOMAIN and the host part of
+# DOMAIN_HOST, so a single-domain deployment works with no extra setting.
+# Production deployments serving several apps should set it explicitly, e.g.
+# ``AUTH_TRUSTED_DOMAINS: trocdigital.io,localhost``.
+AUTH_TRUSTED_DOMAINS = [
+    e.strip()
+    for e in config.get(
+        "AUTH_TRUSTED_DOMAINS",
+        fallback=f"localhost,{DOMAIN},{DOMAIN_HOST}",
+    ).split(",")
+    if e.strip()
+]
+# Optional allow-list of non-HTTP schemes (mobile deep links such as
+# ``navigator://`` or reverse-DNS ``com.example.app:/``). Empty (the default)
+# accepts any custom scheme except the ones a browser would execute
+# (``javascript:``, ``data:`` ...), because the set of Android apps served by
+# the API is open-ended.
+AUTH_TRUSTED_REDIRECT_SCHEMES = [
+    e.strip().lower()
+    for e in config.get("AUTH_TRUSTED_REDIRECT_SCHEMES", fallback="").split(",")
+    if e.strip()
+]
 AUTH_LOGIN_FAILED_URI = config.get("AUTH_LOGIN_FAILED_URI", fallback="/login")
 AUTH_LOGOUT_REDIRECT_URI = config.get("AUTH_LOGOUT_REDIRECT_URI", fallback="/oauth2/logout/complete")
 AUTH_SUCCESSFUL_CALLBACKS = ()

--- a/navigator_auth/libs/redirect.py
+++ b/navigator_auth/libs/redirect.py
@@ -1,0 +1,218 @@
+"""Open-redirect protection for user-supplied redirect targets.
+
+Navigator Auth lets the *frontend* tell the backend where to send the
+browser once authentication finishes (``?redirect_uri=``, SAML
+``RelayState``, the identity-link ``finish_redirect`` ...). One backend
+serves dozens of sub-apps on many sub-domains, so that target cannot be a
+fixed setting; but honouring it verbatim is a classic **open redirect**:
+``https://api.example.com/auth/login?redirect_uri=https://evil.com`` lands
+a freshly minted token on an attacker's page.
+
+:func:`safe_redirect_url` is the single gate every redirect goes through:
+
+* **Relative paths** (``/dashboard``) are always accepted and resolved
+  against the current request's own domain. Protocol-relative
+  (``//evil.com``) and backslash (``/\\evil.com``) forms are rejected.
+* **Absolute ``http(s)`` URLs** are accepted only when the *hostname*
+  (never the raw ``netloc``, which ``user@host`` tricks can spoof) is one
+  of the trusted domains or a subdomain of one. The host serving the
+  current request is always trusted.
+* **Custom schemes** (mobile deep links: ``navigator://``,
+  ``com.example.app:/oauth``) are accepted, optionally restricted to
+  ``AUTH_TRUSTED_REDIRECT_SCHEMES``; schemes a browser would *execute*
+  (``javascript:``, ``data:`` ...) are always rejected.
+
+Anything rejected falls back to the configured default landing page on the
+current domain, so a tampered link degrades gracefully instead of breaking
+the login.
+"""
+from typing import Optional, Iterable
+from urllib.parse import urlparse
+from aiohttp import web
+from navconfig.logging import logging
+from ..conf import (
+    AUTH_TRUSTED_DOMAINS,
+    AUTH_TRUSTED_REDIRECT_SCHEMES,
+    AUTH_REDIRECT_URI,
+    PREFERRED_AUTH_SCHEME,
+)
+
+__all__ = (
+    "FORBIDDEN_SCHEMES",
+    "normalize_domain",
+    "trusted_domains",
+    "is_trusted_host",
+    "is_safe_redirect",
+    "safe_redirect_url",
+)
+
+# Schemes a browser would execute or that never denote another application.
+FORBIDDEN_SCHEMES = frozenset(
+    {"javascript", "data", "vbscript", "file", "blob", "about", "jar", "ftp"}
+)
+_WEB_SCHEMES = frozenset({"http", "https"})
+
+
+def normalize_domain(value: Optional[str]) -> Optional[str]:
+    """Reduce a configured entry to a bare, lower-cased hostname.
+
+    Accepts the forms operators actually write — ``example.com``,
+    ``*.example.com``, ``.example.com``, ``https://example.com:8443/`` or
+    ``localhost:5000`` — and returns ``example.com`` / ``localhost``.
+    ``None`` when nothing usable remains.
+    """
+    if not value:
+        return None
+    value = value.strip().lower()
+    if "://" in value:
+        value = urlparse(value).netloc
+    # user@host:port -> host:port -> host
+    value = value.rsplit("@", 1)[-1]
+    if value.startswith("[") and "]" in value:  # IPv6 literal
+        value = value[1 : value.index("]")]
+    else:
+        value = value.split(":", 1)[0]
+    value = value.lstrip("*").strip(".")
+    return value or None
+
+
+def trusted_domains(extra: Iterable[str] = ()) -> frozenset:
+    """Effective set of trusted base domains (config plus ``extra``)."""
+    entries = list(AUTH_TRUSTED_DOMAINS) + list(extra)
+    return frozenset(d for d in (normalize_domain(e) for e in entries) if d)
+
+
+def _request_hostname(request: Optional[web.Request]) -> Optional[str]:
+    if request is None:
+        return None
+    try:
+        host = request.host
+    except AttributeError:
+        return None
+    return normalize_domain(host)
+
+
+def is_trusted_host(
+    hostname: Optional[str],
+    request: Optional[web.Request] = None,
+    extra_hosts: Iterable[str] = (),
+) -> bool:
+    """``True`` when ``hostname`` is a trusted domain or a subdomain of one.
+
+    The host serving ``request`` (when given) and any ``extra_hosts`` the
+    caller vouches for (e.g. a SAML SP's ACS host) are trusted as well.
+    """
+    hostname = normalize_domain(hostname)
+    if not hostname:
+        return False
+    extra = [h for h in (_request_hostname(request),) if h]
+    extra.extend(extra_hosts)
+    domains = trusted_domains(extra=extra)
+    return any(
+        hostname == domain or hostname.endswith(f".{domain}") for domain in domains
+    )
+
+
+def _split_scheme(url: str) -> tuple[str, str]:
+    """``(scheme, rest)`` with ``scheme`` lower-cased, or ``("", url)``.
+
+    Unlike :func:`urlparse`, ``host:port/path`` is *not* mistaken for a
+    scheme: a purely numeric run right after the colon means a port.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    if not scheme:
+        return "", url
+    rest = url[len(parsed.scheme) + 1 :]
+    port, _, _ = rest.partition("/")
+    if port.isdigit():
+        return "", url
+    return scheme, rest
+
+
+def is_safe_redirect(
+    url: Optional[str],
+    request: Optional[web.Request] = None,
+    extra_hosts: Iterable[str] = (),
+) -> bool:
+    """Whether ``url`` may be used as a redirect target as-is or once resolved.
+
+    ``extra_hosts`` are additional trusted hosts for this call only.
+    """
+    if not isinstance(url, str):
+        return False
+    url = url.strip()
+    if not url or any(ch in url for ch in "\r\n\t\x00"):
+        return False
+    scheme, _ = _split_scheme(url)
+    if not scheme:
+        # Relative reference: refuse protocol-relative ("//host") and the
+        # backslash variants browsers normalise to it ("/\host", "\\host").
+        if url[0] == "\\":
+            return False
+        if url[0] == "/" and len(url) > 1 and url[1] in "/\\":
+            return False
+        return not urlparse(url).netloc
+    if scheme in FORBIDDEN_SCHEMES:
+        return False
+    if scheme in _WEB_SCHEMES:
+        try:
+            parsed = urlparse(url)
+        except ValueError:
+            return False
+        # Browsers (WHATWG) treat "\\" as "/" in http(s) URLs, so
+        # "https://evil.com\\@trusted.io/" is host evil.com to the browser
+        # while urlparse reports trusted.io: refuse the parser differential.
+        if "\\" in parsed.netloc:
+            return False
+        return is_trusted_host(parsed.hostname, request, extra_hosts=extra_hosts)
+    # Custom (deep-link) scheme.
+    if AUTH_TRUSTED_REDIRECT_SCHEMES:
+        return scheme in AUTH_TRUSTED_REDIRECT_SCHEMES
+    return True
+
+
+def _domain_url(request: web.Request) -> str:
+    netloc = urlparse(str(request.url)).netloc
+    return f"{PREFERRED_AUTH_SCHEME}://{netloc}"
+
+
+def _resolve(url: str, domain_url: str) -> str:
+    """Turn a relative path into an absolute URL on ``domain_url``."""
+    scheme, _ = _split_scheme(url)
+    if scheme:
+        return url
+    if not url.startswith("/"):
+        url = f"/{url}"
+    return f"{domain_url}{url}"
+
+
+def safe_redirect_url(
+    request: web.Request,
+    candidate: Optional[str],
+    fallback: Optional[str] = None,
+    domain_url: Optional[str] = None,
+) -> str:
+    """Return the URL the browser may be redirected to.
+
+    ``candidate`` is the untrusted, user-supplied target. When it passes
+    :func:`is_safe_redirect` it is returned, with relative paths resolved
+    against ``domain_url`` (the current request's domain by default). When it
+    does not, a warning is logged and ``fallback`` — an operator-controlled
+    value, ``AUTH_REDIRECT_URI`` by default — is resolved the same way and
+    returned instead, so the login still completes on a safe page.
+    """
+    if domain_url is None:
+        domain_url = _domain_url(request)
+    if fallback is None:
+        fallback = AUTH_REDIRECT_URI or "/"
+    if isinstance(candidate, str):
+        candidate = candidate.strip()
+    if candidate and is_safe_redirect(candidate, request):
+        return _resolve(candidate, domain_url)
+    if candidate:
+        logging.warning(
+            f"Rejected redirect to untrusted target {candidate!r}; "
+            f"falling back to {fallback!r}"
+        )
+    return _resolve(fallback, domain_url)

--- a/tests/test_safe_redirect.py
+++ b/tests/test_safe_redirect.py
@@ -1,0 +1,195 @@
+"""Open-redirect gate: ``navigator_auth.libs.redirect``.
+
+Covers the bypasses the previous per-backend checks let through
+(protocol-relative URLs, ``user@host`` netloc spoofing, glob patterns) and
+the behaviour the multi-app deployment relies on (any subdomain of a trusted
+base domain, relative paths, mobile deep links).
+"""
+import pytest
+from aiohttp.test_utils import make_mocked_request
+
+from navigator_auth.libs import redirect as mod
+from navigator_auth.libs.redirect import (
+    is_safe_redirect,
+    is_trusted_host,
+    normalize_domain,
+    safe_redirect_url,
+    trusted_domains,
+)
+
+
+@pytest.fixture(autouse=True)
+def _trusted(monkeypatch):
+    monkeypatch.setattr(mod, "AUTH_TRUSTED_DOMAINS", ["trocdigital.io", "localhost"])
+    monkeypatch.setattr(mod, "AUTH_TRUSTED_REDIRECT_SCHEMES", [])
+    monkeypatch.setattr(mod, "AUTH_REDIRECT_URI", "/")
+    monkeypatch.setattr(mod, "PREFERRED_AUTH_SCHEME", "https")
+
+
+def _request(host: str = "api.trocdigital.io") -> object:
+    return make_mocked_request("GET", "/auth/login", headers={"Host": host})
+
+
+# --- normalisation ---------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("example.com", "example.com"),
+        (" Example.COM ", "example.com"),
+        ("*.example.com", "example.com"),
+        (".example.com", "example.com"),
+        ("https://example.com:8443/path", "example.com"),
+        ("localhost:5000", "localhost"),
+        ("user@example.com:80", "example.com"),
+        ("[::1]:8080", "::1"),
+        ("", None),
+        (None, None),
+        ("*", None),
+    ],
+)
+def test_normalize_domain(raw, expected):
+    assert normalize_domain(raw) == expected
+
+
+def test_trusted_domains_reads_config_and_extra():
+    assert trusted_domains() == {"trocdigital.io", "localhost"}
+    assert "extra.dev" in trusted_domains(extra=["https://extra.dev:9000"])
+
+
+# --- host trust ------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "host",
+    ["trocdigital.io", "app.trocdigital.io", "a.b.trocdigital.io", "APP.TrocDigital.IO", "localhost"],
+)
+def test_trusted_hosts(host):
+    assert is_trusted_host(host)
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["evil.com", "trocdigital.io.evil.com", "nottrocdigital.io", "localhost.evil.com", "", None],
+)
+def test_untrusted_hosts(host):
+    assert not is_trusted_host(host)
+
+
+def test_request_host_is_always_trusted(monkeypatch):
+    monkeypatch.setattr(mod, "AUTH_TRUSTED_DOMAINS", [])
+    assert is_trusted_host("other.example", _request("other.example:8443"))
+    assert not is_trusted_host("evil.com", _request("other.example:8443"))
+
+
+# --- is_safe_redirect ------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/",
+        "/dashboard",
+        "/dashboard?next=/x&y=1#frag",
+        "dashboard",
+        "https://app.trocdigital.io/home",
+        "http://sub.app.trocdigital.io:8080/home?token=x",
+        "HTTPS://APP.TROCDIGITAL.IO/",
+        "https://localhost:3000/callback",
+        "navigator://login/callback",
+        "myapp:/oauth2redirect",
+        "com.example.app://callback",
+        "com.googleusercontent.apps.123-abc:/oauth2redirect",
+    ],
+)
+def test_safe_targets(url):
+    assert is_safe_redirect(url, _request())
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://evil.com/",
+        "https://evil.com/?x=trocdigital.io",
+        "https://trocdigital.io.evil.com/",
+        "//evil.com/x",
+        "///evil.com",
+        "/\\evil.com",
+        "\\\\evil.com",
+        "https://api.trocdigital.io@evil.com/",
+        "https://localhost@evil.com/",
+        "https://evil.com\\@app.trocdigital.io/",
+        "javascript:alert(1)",
+        "JavaScript:alert(1)",
+        "data:text/html,hi",
+        "vbscript:msgbox",
+        "file:///etc/passwd",
+        "https:///nohost",
+        "https://evil.com/\r\nSet-Cookie: x=1",
+        "",
+        None,
+        123,
+    ],
+)
+def test_unsafe_targets(url):
+    assert not is_safe_redirect(url, _request())
+
+
+def test_custom_scheme_allowlist(monkeypatch):
+    monkeypatch.setattr(mod, "AUTH_TRUSTED_REDIRECT_SCHEMES", ["navigator"])
+    assert is_safe_redirect("navigator://cb", _request())
+    assert is_safe_redirect("NAVIGATOR://cb", _request())
+    assert not is_safe_redirect("otherapp://cb", _request())
+    # the allow-list never re-enables browser-executable schemes
+    monkeypatch.setattr(mod, "AUTH_TRUSTED_REDIRECT_SCHEMES", ["javascript"])
+    assert not is_safe_redirect("javascript:alert(1)", _request())
+
+
+def test_host_port_is_not_a_scheme():
+    # "localhost:5000/x" must not be treated as a custom-scheme deep link
+    assert is_safe_redirect("localhost:5000/x", _request())  # relative-ish path, resolved on our domain
+    assert safe_redirect_url(_request(), "localhost:5000/x").startswith("https://api.trocdigital.io/")
+
+
+# --- safe_redirect_url -----------------------------------------------------
+
+def test_relative_resolved_on_request_domain():
+    assert safe_redirect_url(_request(), "/dashboard") == "https://api.trocdigital.io/dashboard"
+    assert safe_redirect_url(_request(), "dashboard") == "https://api.trocdigital.io/dashboard"
+
+
+def test_trusted_absolute_kept_verbatim():
+    url = "https://app.trocdigital.io/home?x=1"
+    assert safe_redirect_url(_request(), url) == url
+
+
+def test_deep_link_kept_verbatim():
+    assert safe_redirect_url(_request(), "navigator://cb") == "navigator://cb"
+
+
+def test_untrusted_falls_back_to_default(caplog):
+    with caplog.at_level("WARNING"):
+        out = safe_redirect_url(_request(), "https://evil.com/")
+    assert out == "https://api.trocdigital.io/"
+    assert "evil.com" in caplog.text
+
+
+def test_untrusted_falls_back_to_explicit_fallback():
+    assert safe_redirect_url(_request(), "//evil.com", fallback="/login") == "https://api.trocdigital.io/login"
+    fb = "https://app.trocdigital.io/done"
+    assert safe_redirect_url(_request(), "https://evil.com", fallback=fb) == fb
+
+
+def test_missing_candidate_uses_fallback():
+    assert safe_redirect_url(_request(), None) == "https://api.trocdigital.io/"
+    assert safe_redirect_url(_request(), "  ") == "https://api.trocdigital.io/"
+
+
+def test_explicit_domain_url_is_honoured():
+    out = safe_redirect_url(_request(), "/x", domain_url="https://other.trocdigital.io")
+    assert out == "https://other.trocdigital.io/x"
+
+
+def test_extra_hosts_are_trusted_for_that_call_only():
+    assert is_safe_redirect("https://sp.partner.io/acs", _request(), extra_hosts=["sp.partner.io"])
+    assert is_safe_redirect("https://sp.partner.io/acs", _request(), extra_hosts=["sp.partner.io:8443"])
+    assert not is_safe_redirect("https://sp.partner.io/acs", _request())
+    assert not is_safe_redirect("https://sp.partner.io@evil.com/", _request(), extra_hosts=["sp.partner.io"])

--- a/tests/test_saml_foundation.py
+++ b/tests/test_saml_foundation.py
@@ -16,7 +16,7 @@ class _Stub(BaseAuthBackend):
 
 @pytest.fixture
 def backend(monkeypatch):
-    monkeypatch.setattr("navigator_auth.backends.abstract.ALLOWED_HOSTS", ["*.example.com"])
+    monkeypatch.setattr("navigator_auth.libs.redirect.AUTH_TRUSTED_DOMAINS", ["example.com"])
     return _Stub(user_model=None)
 
 

--- a/tests/test_saml_roundtrip.py
+++ b/tests/test_saml_roundtrip.py
@@ -294,13 +294,13 @@ async def test_saml_oauth2_resume_detour(saml_app):
 
 @pytest.mark.xmlsec
 def test_adfs_redirect_validator_unchanged(monkeypatch):
-    """The redirect-validator promotion (TASK-054) preserves ADFS's exact
-    existing behavior."""
+    """ADFS's relay validator keeps its verdict-style contract on top of the
+    AUTH_TRUSTED_DOMAINS gate."""
     from unittest.mock import MagicMock as _MM
 
     from navigator_auth.backends.adfs import ADFSAuth
 
-    monkeypatch.setattr("navigator_auth.backends.abstract.ALLOWED_HOSTS", ["*.example.com"])
+    monkeypatch.setattr("navigator_auth.libs.redirect.AUTH_TRUSTED_DOMAINS", ["example.com"])
     backend = object.__new__(ADFSAuth)
     backend.logger = _MM()
     backend._service = "ADFSAuth"


### PR DESCRIPTION
## Summary

Fixes an **open redirect** in the login flows. Every frontend-supplied redirect target (`?redirect_uri=` on login routes, SAML `RelayState`, Azure/ADFS `internal_redirect`, the identity-link `finish_redirect`) was honoured verbatim when absolute, handing a freshly minted token to any host. The shared `validate_redirect_host` check glob-matched the raw `netloc` against `ALLOWED_HOSTS`, so `//evil.com`, `https://localhost@evil.com` and `localhost.evil.com` all passed.

The backend serves dozens of sub-apps on many sub-domains and the frontend decides where to land, so the target cannot be a fixed setting. Instead there is now one gate every redirect goes through.

## Changes

- **`navigator_auth/libs/redirect.py`** — `safe_redirect_url` / `is_safe_redirect`:
  - relative paths always accepted, resolved on the current request's domain; `//host`, `/\host` and backslash-in-authority forms rejected;
  - absolute `http(s)` accepted only when the **hostname** (never the raw netloc) is under `AUTH_TRUSTED_DOMAINS`, the host serving the request, or hosts the caller vouches for (`extra_hosts`, e.g. a SAML SP's ACS host);
  - custom deep-link schemes (`navigator://`, `com.example.app:/`) accepted, optionally restricted via `AUTH_TRUSTED_REDIRECT_SCHEMES`; `javascript:`/`data:`/`file:` never;
  - rejection logs a warning and falls back to `AUTH_REDIRECT_URI`, so a tampered link degrades to the landing page instead of breaking the login.
- **`conf.py`** — `AUTH_TRUSTED_DOMAINS` (default: `localhost`, `DOMAIN`, host of `DOMAIN_HOST`; entries like `*.example.com` or `https://x.io:8443` are normalised) and `AUTH_TRUSTED_REDIRECT_SCHEMES` (default empty = any non-executable custom scheme).
- Wired into `BaseAuthBackend.get_finish_redirect_url` / `uri_redirect`, `ExternalAuth.get_finish_redirect_url` / `home_redirect`, the identity-link callback, and `BaseAuthBackend.validate_redirect_host` (ADFS relay, SAML RelayState / `redirect_uri`) rebuilt on the same gate. The OAuth2 authorization server is untouched: it already exact-matches `redirect_uri` against the registered client.
- Docs: `documentation/trusted-redirects.md`; `CHANGELOG.md` entry.

## Tests

- New `tests/test_safe_redirect.py` (66 cases: bypasses above as negatives; subdomains, relative paths, deep links, `extra_hosts` as positives).
- `test_saml_foundation.py` / `test_saml_roundtrip.py` now monkeypatch `AUTH_TRUSTED_DOMAINS` instead of `ALLOWED_HOSTS`.
- Full suite: 1410 passed, 12 failed. The 12 are pre-existing and reproduce identically on untouched `dev` (live-server connection, JWT/cryptography warnings escalated by `filterwarnings=error`, yaml-storage event loop, cipher key rotation, and a non-awaitable `MagicMock` in `get_callback_state` from the SAML merge). None touch redirect code.

## Deployment note

Production deployments serving several apps should set `AUTH_TRUSTED_DOMAINS` explicitly (e.g. `trocdigital.io,localhost`); the default only covers the domain the API itself is configured with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qev9U9oyQm5vKCRjhXeYuJ
